### PR TITLE
Allow data frames to be used as renderDataTable values

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -53,7 +53,18 @@ renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
   )
   checkShinyVersion()
   if (!quoted) expr = substitute(expr)
-  htmlwidgets::shinyRenderWidget(expr, dataTableOutput, env, quoted = TRUE)
+
+  exprFunc <- shiny::exprToFunction(expr, env, quoted = TRUE)
+  widgetFunc <- function() {
+    x <- exprFunc()
+    if (is.data.frame(x)) {
+      datatable(x)
+    } else {
+      x
+    }
+  }
+
+  htmlwidgets::shinyRenderWidget(widgetFunc(), dataTableOutput, environment(), FALSE)
 }
 
 shinyFun = function(name) getFromNamespace(name, 'shiny')


### PR DESCRIPTION
Sorry, last time I had the final `quoted=TRUE` where it should've been `quoted=FALSE`.