### PR TITLE
Simplify server handling

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -147,7 +147,9 @@ datatable = function(
   if (server) {
     origData = data
     data = NULL
-    options = fixServerOptions(options, escape, colnames)
+    # indices of columns that need to be escaped
+    attr(options, 'escapeIdx') = escapeToConfig(escape, colnames)
+    options = fixServerOptions(options)
 
     # register the data object in a shiny session
     registerData = function(instance, shinysession, name) {
@@ -159,7 +161,7 @@ datatable = function(
 
       url = sessionDataURL(shinysession, origData, name, dataTablesFilter)
       options$ajax$url = url
-      instance$x$options = fixServerOptions(options, escape, colnames)
+      instance$x$options = fixServerOptions(options)
 
       instance
     }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -74,7 +74,7 @@ renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
 
   renderFunc <- htmlwidgets::shinyRenderWidget(widgetFunc(), dataTableOutput, environment(), FALSE)
 
-  markRenderFunction(dataTableOutput, function(shinysession, name, ...) {
+  shiny::markRenderFunction(dataTableOutput, function(shinysession, name, ...) {
     currentSession <<- shinysession
     currentOutputName <<- name
     on.exit({

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -53,7 +53,18 @@ renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
   )
   checkShinyVersion()
   if (!quoted) expr = substitute(expr)
-  htmlwidgets::shinyRenderWidget(expr, dataTableOutput, env, quoted = TRUE)
+
+  exprFunc <- shiny::exprToFunction(expr, env, quoted = TRUE)
+  widgetFunc <- function() {
+    x <- exprFunc()
+    if (is.data.frame(x)) {
+      datatable(x)
+    } else {
+      x
+    }
+  }
+
+  htmlwidgets::shinyRenderWidget(widgetFunc(), dataTableOutput, environment(), FALSE)
 }
 
 shinyFun = function(name) getFromNamespace(name, 'shiny')

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -60,7 +60,8 @@ renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
       instance = datatable(instance, ...)
     }
 
-    instance <- instance$preRenderHook(instance, currentSession, currentOutputName)
+    if (is.function(hook <- instance$preRenderHook))
+      instance <- hook(instance, currentSession, currentOutputName)
     instance$preRenderHook <- NULL
 
     instance

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -60,10 +60,8 @@ renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
   exprFunc <- shiny::exprToFunction(expr, env, quoted = TRUE)
   widgetFunc <- function() {
     instance <- exprFunc()
-    if (is.data.frame(instance)) {
-      datatable(instance)
-    } else {
-      instance
+    if (!all(c('datatables', 'htmlwidget') %in% class(instance))) {
+      instance = datatable(instance)
     }
 
     instance <- instance$preRenderHook(instance, currentSession, currentOutputName)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -42,15 +42,11 @@ dataTableOutput = function(outputId, width = '100%', height = 'auto') {
 #' @rdname dataTableOutput
 #' @inheritParams shiny::renderDataTable
 #' @param expr an expression to create a table widget (normally via
-#'   \code{\link{datatable}()})
-#' @param ... currently ignored, with a warning message
+#'   \code{\link{datatable}()}), or a data object to be passed to
+#'   \code{datatable()} to create a table widget
+#' @param ... ignored when \code{expr} returns a table widget, and passed to
+#'   \code{datatable()} when \code{expr} returns a data object
 renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
-  if (length(list(...))) warning(
-    "Arguments in addition to 'expr', 'env', and 'quoted' are ignored. ",
-    "If you came from shiny::renderDataTable(), you may want to pass ",
-    "these arguments to DT::datatable() instead. See ",
-    "http://rstudio.github.io/DT/shiny.html for more info."
-  )
   checkShinyVersion()
   if (!quoted) expr = substitute(expr)
 
@@ -61,7 +57,7 @@ renderDataTable = function(expr, env = parent.frame(), quoted = FALSE, ...) {
   widgetFunc <- function() {
     instance <- exprFunc()
     if (!all(c('datatables', 'htmlwidget') %in% class(instance))) {
-      instance = datatable(instance)
+      instance = datatable(instance, ...)
     }
 
     instance <- instance$preRenderHook(instance, currentSession, currentOutputName)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -270,7 +270,7 @@ dotsToRange = function(string) {
   r
 }
 
-fixServerOptions = function(options, escape, colnames) {
+fixServerOptions = function(options) {
   options$serverSide = TRUE
   if (is.null(options$processing)) options$processing = TRUE
 
@@ -287,7 +287,7 @@ fixServerOptions = function(options, escape, colnames) {
       'd.search.caseInsensitive = %s;',
       tolower(!isFALSE(options[['search']]$caseInsensitive))
     ),
-    sprintf('d.escape = %s;', escapeToConfig(escape, colnames)),
+    sprintf('d.escape = %s;', attr(options, 'escapeIdx', exact = TRUE)),
     '}'
   )
   options

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -16,14 +16,16 @@ renderDataTable(expr, env = parent.frame(), quoted = FALSE, ...)
 \item{height}{the height of the table container}
 
 \item{expr}{an expression to create a table widget (normally via
-\code{\link{datatable}()})}
+\code{\link{datatable}()}), or a data object to be passed to
+\code{datatable()} to create a table widget}
 
 \item{env}{The environment in which to evaluate \code{expr}.}
 
 \item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
 
-\item{...}{currently ignored, with a warning message}
+\item{...}{ignored when \code{expr} returns a table widget, and passed to
+\code{datatable()} when \code{expr} returns a data object}
 }
 \description{
 These two functions are like most \code{fooOutput()} and \code{renderFoo()}


### PR DESCRIPTION
This is a **straw man** proposal for how we could do this without requiring https://github.com/ramnathv/htmlwidgets/pull/122. It pulls in your no-register branch.

There are two hacks to point out, plus an open issue I think we should discuss.

Hack 1 is that the `preRenderHook` is evaluated and then removed in `widgetFunc`. This works fine but it feels like it definitely violates the spirit of `preRenderHook`. My first attempt tried to remove the preRenderHook altogether and copy that logic into the Shiny render function, but I couldn't figure out how to get the `escape` and `colnames` out. I thought that would be a pretty easy refactor for you, but I didn't want to go that far afield for this proof-of-concept.

Hack 2 is the usage of `currentSession` and `currentOutputName` variables, that we use to transmit the session and name from the render function to the `widgetFunc`. This is a bit inelegant but I'm totally fine with shipping with this, as it's unlikely to cause bugs and certainly doesn't affect the user experience negatively.

Open issue is whether `server = TRUE` belongs on `datatable()` in the first place, or whether it should be on `renderDataTable` as it is in Shiny today. I think the latter makes at least as much sense as the former, since `server` mode is only possible with Shiny anyway. On the other hand, it would be unfortunate to break DT backwards compatibility. On the gripping hand, I'd rather break compatibility with DT now than in the future, and I'd slightly prefer to break with DT than with the renderDataTable function Shiny has shipped for ages now.

I'll be at lunch from 12pm-1:20pm PDT or so, but I'll be available to talk about this after that if you want.