### PR TITLE
Move `server` parameter from datatable to renderDataTable

### DIFF
--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -6,7 +6,7 @@
 \usage{
 dataTableOutput(outputId, width = "100\%", height = "auto")
 
-renderDataTable(expr, env = parent.frame(), quoted = FALSE, ...)
+renderDataTable(expr, server = TRUE, env = parent.frame(), quoted = FALSE, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the table from}
@@ -19,13 +19,20 @@ renderDataTable(expr, env = parent.frame(), quoted = FALSE, ...)
 \code{\link{datatable}()}), or a data object to be passed to
 \code{datatable()} to create a table widget}
 
+\item{server}{whether to use server-side processing. If \code{TRUE}, then the
+data is kept on the server and the browser requests a page at a time; if
+\code{FALSE}, then the entire data frame is sent to the browser at once.
+Highly recommended for medium to large data frames, which can cause
+browsers to slow down or crash.}
+
 \item{env}{The environment in which to evaluate \code{expr}.}
 
 \item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
 
-\item{...}{ignored when \code{expr} returns a table widget, and passed to
-\code{datatable()} when \code{expr} returns a data object}
+\item{...}{ignored when \code{expr} returns a table widget, and passed as
+additional arguments to \code{datatable()} when \code{expr} returns a data
+object}
 }
 \description{
 These two functions are like most \code{fooOutput()} and \code{renderFoo()}

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -4,9 +4,9 @@
 \title{Create an HTML table widget using the DataTables library}
 \usage{
 datatable(data, options = list(), class = "display", callback = JS("return table;"), 
-    rownames, colnames, container, caption = NULL, filter = c("none", 
-        "bottom", "top"), server = FALSE, escape = TRUE, style = "default", 
-    selection = c("multiple", "single", "none"), extensions = list())
+    rownames, colnames, container, caption = NULL, filter = c("none", "bottom", "top"), 
+    escape = TRUE, style = "default", selection = c("multiple", "single", "none"), 
+    extensions = list())
 }
 \arguments{
 \item{data}{a data object (either a matrix or a data frame)}
@@ -53,10 +53,6 @@ this argument of the form \code{list(position = 'top', clear = TRUE, plain
 = FALSE)}, where \code{clear} indicates whether you want the clear buttons
 in the input boxes, and \code{plain} means if you want to use Bootstrap
 form styles or plain text input styles for the text input boxes}
-
-\item{server}{whether to use server-side processing; if \code{TRUE}, you must
-provide a server URL so that DataTables can send Ajax requests to retrieve
-data from the server}
 
 \item{escape}{whether to escape HTML entities in the table: \code{TRUE} means
 to escape the whole table, and \code{FALSE} means not to escape it;


### PR DESCRIPTION
I know I said I was OK with us not doing this but I decided it was worth
it after all, for the following benefits:

1. Allows us to default server=TRUE when in a Shiny app
2. Allows server=TRUE to be specified identically whether datatable() or
   data frame is returned in the renderDataTable expr
3. Prevents the nonsensical specification of server=TRUE when using DT
   in a non-Shiny context

The code is actually quite a bit simpler than before I think, though
there is a nontrivial risk of regression.