### PR TITLE
Using comparators for filtering table ('=', '>=', '<=')

### DIFF
--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -332,9 +332,21 @@ HTMLWidgets.widget({
               if ($input.val() === '') filter.val([r1, r2]);
             },
             change: function() {
-              var v = $input.val().replace(/\s/g, '');
-              if (v === '') return;
-              v = v.split('...');
+              var val = $input.val().replace(/\s/g, '');
+              if (val === '') return;
+              v = val.split('...');
+
+              // filter using comparators ('=', '>=', '<=')
+              if (v.length == 1) {
+                if (val.lastIndexOf(">=",0) == 0) {
+                  v = [val.substring(2), r2];
+                } else if (val.lastIndexOf("<=",0) == 0) {
+                  v = [r1, val.substring(2)];
+                } else if (val.lastIndexOf("=",0) == 0) {
+                  v = [val.substring(1), val.substring(1)];
+                } 
+              } 
+
               if (v.length !== 2) {
                 $input.parent().addClass('has-error');
                 return;


### PR DESCRIPTION
Currently, it is possible to filter for values with 'X...', '...X' and 'X...X'. 

This pull request enables an alternative way of setting the filter in numeric or date-time columns with '>=X', '<=X' and '=X'.

This is basically the same as pull request #210. I was asked for a combined commit for a nicer history. 

Thanks!
