### PR TITLE
improvements to sizing behavior

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -46,7 +46,8 @@
 #'   third), or \code{c('Species', 'Sepal.Length')}
 #' @param style the style name (\url{http://datatables.net/manual/styling/});
 #'   currently only \code{'default'} and \code{'bootstrap'} are supported
-#' @param width the width of the table
+#' @param width Width in pixels (optional, defaults to automatic sizing)
+#' @param height Height in pixels (optional, defaults to automatic sizing)
 #' @param fillContainer \code{TRUE} to configure the table to automatically fill
 #'   it's containing element. If the table can't fit fully into it's container
 #'   then vertical and/or horizontal scrolling of the table cells will occur.
@@ -74,7 +75,7 @@
 datatable = function(
   data, options = list(), class = 'display', callback = JS('return table;'),
   rownames, colnames, container, caption = NULL, filter = c('none', 'bottom', 'top'),
-  escape = TRUE, style = 'default', width = '100%',
+  escape = TRUE, style = 'default', width = NULL, height = NULL,
   fillContainer = getOption('DT.fillContainer', NULL),
   autoHideNavigation = getOption('DT.autoHideNavigation', NULL),
   selection = c('multiple', 'single', 'none'), extensions = list(), plugins = NULL
@@ -237,15 +238,18 @@ datatable = function(
   if (length(plugins))
     deps = c(deps, lapply(plugins, pluginDependency))
 
-  # tweak width and height based on fillContainer
-  height = NULL
-  if (isTRUE(fillContainer))
+  # force width and height to NULL for fillContainer
+  if (isTRUE(fillContainer)) {
     width = NULL
+    height = NULL
+  }
 
   htmlwidgets::createWidget(
     'datatables', if (hideDataTable) NULL else params,
     package = 'DT', width = width, height = height,
-    sizingPolicy = htmlwidgets::sizingPolicy(knitr.figure = FALSE),
+    sizingPolicy = htmlwidgets::sizingPolicy(knitr.figure = FALSE,
+                                             knitr.defaultWidth = "100%",
+                                             knitr.defaultHeight = "auto"),
     dependencies = deps, preRenderHook = function(instance) {
 
       data = instance[['x']][['data']]

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -75,8 +75,8 @@ datatable = function(
   data, options = list(), class = 'display', callback = JS('return table;'),
   rownames, colnames, container, caption = NULL, filter = c('none', 'bottom', 'top'),
   escape = TRUE, style = 'default', width = '100%',
-  fillContainer = getOption('DT.fillContainer', FALSE),
-  autoHideNavigation = getOption('DT.autoHideNavigation', FALSE),
+  fillContainer = getOption('DT.fillContainer', NULL),
+  autoHideNavigation = getOption('DT.autoHideNavigation', NULL),
   selection = c('multiple', 'single', 'none'), extensions = list(), plugins = NULL
 ) {
 
@@ -151,7 +151,7 @@ datatable = function(
   if (style != 'default') params$style = style
 
   # add class for fillContainer if necessary
-  if (fillContainer)
+  if (isTRUE(fillContainer))
     class = paste(class, 'fill-container');
 
   if (is.character(filter)) filter = list(position = match.arg(filter))
@@ -204,8 +204,8 @@ datatable = function(
   }
 
   # record fillContainer and autoHideNavigation
-  if (fillContainer) params$fillContainer = fillContainer
-  if (autoHideNavigation) params$autoHideNavigation = autoHideNavigation
+  if (!is.null(fillContainer)) params$fillContainer = fillContainer
+  if (!is.null(autoHideNavigation)) params$autoHideNavigation = autoHideNavigation
 
   params = structure(modifyList(params, list(
     data = data, container = as.character(container), options = options,
@@ -238,16 +238,14 @@ datatable = function(
     deps = c(deps, lapply(plugins, pluginDependency))
 
   # tweak width and height based on fillContainer
-  height = 'auto'
-  if (fillContainer) {
+  height = NULL
+  if (isTRUE(fillContainer))
     width = NULL
-    height = NULL
-  }
 
   htmlwidgets::createWidget(
     'datatables', if (hideDataTable) NULL else params,
     package = 'DT', width = width, height = height,
-    sizingPolicy = htmlwidgets::sizingPolicy(browser.fill = TRUE),
+    sizingPolicy = htmlwidgets::sizingPolicy(knitr.figure = FALSE),
     dependencies = deps, preRenderHook = function(instance) {
 
       data = instance[['x']][['data']]

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -92,6 +92,15 @@ HTMLWidgets.widget({
       data.fillContainer = false;
     }
 
+    // if we are in the viewer then we always want to fillContainer and
+    // and autoHideNavigation (unless the user has explicitly set these)
+    if (window.HTMLWidgets.viewerMode) {
+      if (!data.hasOwnProperty("fillContainer"))
+        data.fillContainer = true;
+      if (!data.hasOwnProperty("autoHideNavigation"))
+        data.autoHideNavigation = true;
+    }
+
     // propagate fillContainer to instance (so we have it in resize)
     instance.fillContainer = data.fillContainer;
 

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -5,11 +5,11 @@
 \usage{
 datatable(data, options = list(), class = "display", callback = JS("return table;"), 
     rownames, colnames, container, caption = NULL, filter = c("none", 
-        "bottom", "top"), escape = TRUE, style = "default", 
-    width = "100\%", fillContainer = getOption("DT.fillContainer", 
-        NULL), autoHideNavigation = getOption("DT.autoHideNavigation", 
-        NULL), selection = c("multiple", "single", "none"), 
-    extensions = list(), plugins = NULL)
+        "bottom", "top"), escape = TRUE, style = "default", width = NULL, 
+    height = NULL, fillContainer = getOption("DT.fillContainer", NULL), 
+    autoHideNavigation = getOption("DT.autoHideNavigation", NULL), 
+    selection = c("multiple", "single", "none"), extensions = list(), 
+    plugins = NULL)
 }
 \arguments{
 \item{data}{a data object (either a matrix or a data frame)}
@@ -67,7 +67,9 @@ third), or \code{c('Species', 'Sepal.Length')}}
 \item{style}{the style name (\url{http://datatables.net/manual/styling/});
 currently only \code{'default'} and \code{'bootstrap'} are supported}
 
-\item{width}{the width of the table}
+\item{width}{Width in pixels (optional, defaults to automatic sizing)}
+
+\item{height}{Height in pixels (optional, defaults to automatic sizing)}
 
 \item{fillContainer}{\code{TRUE} to configure the table to automatically fill
 it's containing element. If the table can't fit fully into it's container

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -7,8 +7,8 @@ datatable(data, options = list(), class = "display", callback = JS("return table
     rownames, colnames, container, caption = NULL, filter = c("none", 
         "bottom", "top"), escape = TRUE, style = "default", 
     width = "100\%", fillContainer = getOption("DT.fillContainer", 
-        FALSE), autoHideNavigation = getOption("DT.autoHideNavigation", 
-        FALSE), selection = c("multiple", "single", "none"), 
+        NULL), autoHideNavigation = getOption("DT.autoHideNavigation", 
+        NULL), selection = c("multiple", "single", "none"), 
     extensions = list(), plugins = NULL)
 }
 \arguments{


### PR DESCRIPTION
This PR makes a couple of changes to sizing behavior aimed at making DT play better within notebooks and the viewer pane:

1. Explicit `width` and `height` values are no longer used in constructing the widget (unless the user passes them explicitly). Formerly, a default width of 100% and default height of "auto" were being used. These explicit values were subsequently foiling attempts to have DT fill all available space within the RStudio Viewer and in notebook mode. 

The sizing for Shiny was already being specified as width = "100%" and height = "auto", so it seems as if these widths and heights were being set for the benefit of knitr output. However, htmlwdiget sizing policies enable specification of knitr specific sizing behavior, so the following code should have the same effect:

```r
htmlwidgets::sizingPolicy(knitr.figure = FALSE,  
                          knitr.defaultWidth = "100%",  
                          knitr.defaultHeight = "auto")
```

This covers sizing for the knitr and Shiny cases so we can now pass NULL for both width and height. This in turns results in the following behavior:

- Filling of the container for the Viewer and the Notebook
- Auto width and height for full browser views

2. DT now detects when it is within the RStudio Viewer / Notebook and automatically sets fillContainer to TRUE. 





