### PR TITLE
Crosstalk integration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,9 @@ Suggests:
     jsonlite (>= 0.9.16),
     knitr (>= 1.8),
     rmarkdown,
-    shiny (>= 0.12.1)
+    shiny (>= 0.12.1),
+    crosstalk
+Remotes:
+    rstudio/crosstalk
 VignetteBuilder: knitr
 RoxygenNote: 5.0.1

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -91,6 +91,20 @@ datatable = function(
   )
   params = list()
 
+  if (crosstalk::is.SharedData(data)) {
+    crosstalkOptions <- list(
+      key = data$key(),
+      group = data$groupName()
+    )
+    data <- data$data(withSelection = FALSE, withFilter = TRUE, withKey = FALSE)
+  } else {
+    crosstalkOptions <- list(
+      key = NULL,
+      group = NULL
+    )
+  }
+  options$crosstalkOptions <- crosstalkOptions
+
   # deal with row names: rownames = TRUE or missing, use rownames(data)
   rn = if (missing(rownames) || isTRUE(rownames)) base::rownames(data) else {
     if (is.character(rownames)) rownames  # use custom row names

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -243,6 +243,8 @@ datatable = function(
     deps = c(deps, list(pluginDependency('searchHighlight')))
   if (length(plugins))
     deps = c(deps, lapply(plugins, pluginDependency))
+  if (!is.null(crosstalkOptions$group))
+    deps = c(deps, crosstalk::crosstalkLibs())
 
   # force width and height to NULL for fillContainer
   if (isTRUE(fillContainer)) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -60,6 +60,10 @@ renderDataTable = function(expr, server = TRUE, env = parent.frame(), quoted = F
 
     # in the server mode, we should not store the full data in JSON
     if (server && !is.null(instance[['x']])) {
+      if (!is.null(instance$x$options$crosstalkOptions$group)) {
+        stop("Crosstalk only works with DT client mode: DT::renderDataTable({...}, server=FALSE)")
+      }
+
       origData = instance[['x']][['data']]
       instance$x$data = NULL
 

--- a/inst/htmlwidgets/css/datatables-crosstalk.css
+++ b/inst/htmlwidgets/css/datatables-crosstalk.css
@@ -1,0 +1,3 @@
+.dt-crosstalk-fade {
+  opacity: 0.2;
+}

--- a/inst/htmlwidgets/css/datatables-crosstalk.css
+++ b/inst/htmlwidgets/css/datatables-crosstalk.css
@@ -1,3 +1,7 @@
 .dt-crosstalk-fade {
   opacity: 0.2;
 }
+
+html body div.DTS div.dataTables_scrollBody {
+  background: none;
+}

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -303,6 +303,7 @@ HTMLWidgets.widget({
       }
       var crosstalkSelection = crosstalk.group(data.options.crosstalkOptions.group).var("selection");
       crosstalkSelection.on("change", applyCrosstalkSelection);
+      // TODO: This next line doesn't seem to work when renderDataTable is used
       applyCrosstalkSelection({value: crosstalkSelection.get()});
     }
 
@@ -678,9 +679,19 @@ HTMLWidgets.widget({
       // HACK
       if (event === "rows_selected" && !noCrosstalk) {
         if (data.options.crosstalkOptions.group) {
+          var keys = data.options.crosstalkOptions.key;
+          var selectedKeys = null;
+          if (value) {
+            selectedKeys = [];
+            for (var i = 0; i < value.length; i++) {
+              // The value array's contents use 1-based row numbers, so we must
+              // convert to 0-based before indexing into the keys array.
+              selectedKeys.push(keys[value[i] - 1]);
+            }
+          }
           crosstalk.group(data.options.crosstalkOptions.group)
             .var("selection")
-            .set(value, {sender: el});
+            .set(selectedKeys, {sender: el});
         }
       }
     };

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -110,7 +110,7 @@ HTMLWidgets.widget({
     if (data.options.crosstalkOptions.group) {
       maybeInstallCrosstalkPlugins();
       var ctGroup = data.options.crosstalkOptions.group;
-      data.options.crosstalkOptions.filterHandle = crosstalk.filter.createHandle(crosstalk.group(ctGroup));
+      data.options.crosstalkOptions.filterHandle = new crosstalk.FilterHandle(ctGroup);
     }
 
     // If we are in a flexdashboard scroll layout then we:
@@ -254,7 +254,7 @@ HTMLWidgets.widget({
       $table[0].ctfilter = null;
       $table[0].ctselect = null;
     } else {
-      var crosstalkFilter = crosstalk.filter.createHandle(crosstalk.group(data.options.crosstalkOptions.group));
+      var crosstalkFilter = new crosstalk.FilterHandle(data.options.crosstalkOptions.group);
       var key = data.options.crosstalkOptions.key;
       function keysToMatches(keys) {
         if (!keys) {
@@ -301,10 +301,10 @@ HTMLWidgets.widget({
           }
         }
       }
-      var crosstalkSelection = crosstalk.group(data.options.crosstalkOptions.group).var("selection");
+      var crosstalkSelection = new crosstalk.SelectionHandle(data.options.crosstalkOptions.group);
       crosstalkSelection.on("change", applyCrosstalkSelection);
       // TODO: This next line doesn't seem to work when renderDataTable is used
-      applyCrosstalkSelection({value: crosstalkSelection.get()});
+      applyCrosstalkSelection({value: crosstalkSelection.value});
     }
 
     var inArray = function(val, array) {
@@ -689,9 +689,9 @@ HTMLWidgets.widget({
               selectedKeys.push(keys[value[i] - 1]);
             }
           }
-          crosstalk.group(data.options.crosstalkOptions.group)
-            .var("selection")
-            .set(selectedKeys, {sender: el});
+          var ctsel = new crosstalk.SelectionHandle(data.options.crosstalkOptions.group);
+          ctsel.set(selectedKeys, {sender: el});
+          ctsel.close();
         }
       }
     };

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -235,10 +235,12 @@ HTMLWidgets.widget({
 
     var table = $table.DataTable(options);
     $el.data('datatable', table);
-    if (data.options.crosstalkOptions.group) {
+    if (!data.options.crosstalkOptions.group) {
+      $table[0].ctfilter = null;
+    } else {
       var crosstalkFilter = crosstalk.filter.createHandle(crosstalk.group(data.options.crosstalkOptions.group));
       var key = data.options.crosstalkOptions.key;
-      crosstalkFilter.on("change", function(e) {
+      crosstalkFilter.on("change", function applyCrosstalkFilter(e) {
         if (!e.value) {
           $table[0].ctfilter = null;
           table.draw();
@@ -256,6 +258,7 @@ HTMLWidgets.widget({
           table.draw();
         }
       });
+      applyCrosstalkFilter({value: crosstalkFilter.filteredKeys});
     }
 
     var inArray = function(val, array) {

--- a/inst/htmlwidgets/datatables.yaml
+++ b/inst/htmlwidgets/datatables.yaml
@@ -3,3 +3,7 @@ dependencies:
     version: 1.12.4
     src: "htmlwidgets/lib/jquery"
     script: jquery.min.js
+  - name: datatables-css
+    version: 0.0.0
+    src: "htmlwidgets/css"
+    stylesheet: datatables-crosstalk.css


### PR DESCRIPTION
Console example:

```r
devtools::install_github("jcheng5/d3scatter")

library(crosstalk)
library(DT)
library(d3scatter)

sd <- SharedData$new(iris)
bscols(
  d3scatter(sd, ~Petal.Length, ~Petal.Width, ~Species, width = "100%"),
  datatable(sd, width = "100%")
)
```

Shiny example (requires github version of leaflet):

```r
library(shiny)
library(crosstalk)
library(d3scatter)
library(leaflet)
library(DT)

options(shiny.launch.browser = TRUE)

ui <- fluidPage(
  d3scatterOutput("scatter", height = 250),
  leafletOutput("map", height = 250),
  selectInput("dataset", "Data set to show in table:", c("iris", "quakes"), "iris"),
  DT::dataTableOutput("table", height = 250)
)

server <- function(input, output, session) {
  sd_iris <- SharedData$new(iris, group = "iris")
  sd_quakes <- SharedData$new(quakes, group = "quakes")
  
  output$scatter <- renderD3scatter({
    d3scatter(sd_iris, ~Petal.Length, ~Petal.Width, ~Species)
  })
  
  output$map <- renderLeaflet({
    leaflet(sd_quakes) %>% addTiles() %>% addMarkers()
  })
  
  output$table <- DT::renderDataTable({
    DT::datatable(switch(input$dataset, iris = sd_iris, quakes = sd_quakes))
  }, server = FALSE)
}

shinyApp(ui, server)
```