### PR TITLE
Fix Crosstalk bug due to bad variable rename

### DIFF
--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -287,7 +287,7 @@ HTMLWidgets.widget({
       applyCrosstalkFilter({value: instance.ctfilterHandle.filteredKeys});
 
       function applyCrosstalkSelection(e) {
-        if (e.sender !== instance.ctselect) {
+        if (e.sender !== instance.ctselectHandle) {
           table
             .rows('.' + selClass, {search: 'applied'})
             .nodes()
@@ -297,7 +297,7 @@ HTMLWidgets.widget({
             changeInput('rows_selected', selectedRows(), void 0, true);
         }
 
-        if (e.sender !== instance.ctselect && e.value && e.value.length) {
+        if (e.sender !== instance.ctselectHandle && e.value && e.value.length) {
           $table[0].ctselect = keysToMatches(e.value);
           table.draw();
         } else {


### PR DESCRIPTION
I had changed instance.ctselect to instance.ctselectHandle, but due to bad Find criteria I
missed some of the references. The effect of this bug was that selecting rows in the DT
would cause the same table to respond to the selection as if it was originating elsewhere,
so all but the selected rows would be hidden.