### PR TITLE
Always include Crosstalk dependencies

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -243,8 +243,7 @@ datatable = function(
     deps = c(deps, list(pluginDependency('searchHighlight')))
   if (length(plugins))
     deps = c(deps, lapply(plugins, pluginDependency))
-  if (!is.null(crosstalkOptions$group))
-    deps = c(deps, crosstalk::crosstalkLibs())
+  deps = c(deps, crosstalk::crosstalkLibs())
 
   # force width and height to NULL for fillContainer
   if (isTRUE(fillContainer)) {


### PR DESCRIPTION
The JavaScript bindings are structured in such a way that Crosstalk
dependencies are always needed. This results in an extra ~19KB
(minified) JS dependency. We could definitely remove this dependency by
being more careful in the JS bindings not to touch crosstalk.* until a
group is passed in, but in the meantime this fixes fatal errors.