### PR TITLE
Fix encoding for non-ASCII factor levels in filterHTML

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -410,7 +410,7 @@ filterRow = function(
       if (t != 'disabled') tags$div(
         tags$select(
           multiple = 'multiple', style = 'width: 100%;',
-          `data-options` = jsonlite::toJSON(as.character(d))
+          `data-options` = enc2native(jsonlite::toJSON(as.character(d)))
         ),
         style = 'width: 100%; display: none;'
       )


### PR DESCRIPTION
When factor levels in columns include non-ASCII characters, the filterHTML \<select\> shows encoding issues on Windows platforms. See [this Gist](https://gist.github.com/giancarlok/eb5c7a3f5fc4b6d84f03ed4f71830b66) for a MCVE. When explicitly converting jsonlite's return value to the native encoding, htmltools can handle these characters correctly. See PR for an implementation of this fix. Further credits go to @verticube for debugging and fixing this issue.