### PR TITLE
fix #476 

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -125,9 +125,15 @@ datatable = function(
   }
 
   # align numeric columns to the right
-  if (length(numc)) options = appendColumnDefs(
-    options, list(className = 'dt-right', targets = numc - 1)
-  )
+  if (length(numc)) {
+    # if the `className` of the column has already been defined by the user,
+    # we should not touch it.
+    defined_cols <- classNameDefinedColumns(options)
+    undefined_numc <- (numc - 1)[!(numc - 1) %in% defined_cols]
+    if (length(undefined_numc)) options = appendColumnDefs(
+      options, list(className = 'dt-right', targets = undefined_numc)
+    )
+  }
 
   # make sure the table is _not_ ordered by default (change the DataTables default)
   if (is.null(options[['order']])) options$order = list()
@@ -274,6 +280,17 @@ appendColumnDefs = function(options, def) {
   options$columnDefs = defs
   options
 }
+
+classNameDefinedColumns = function(options) {
+  defs = options[['columnDefs']]
+  if (is.null(defs) || length(defs) == 0L) return(integer())
+  colDefinedTgts <- function(init, x) {
+    if (!is.null(x[['className']])) return(c(init, x[['targets']]))
+    init
+  }
+  unique(Reduce(colDefinedTgts, defs, integer()))
+}
+
 
 # convert character indices to numeric
 convertIdx = function(i, names, n = length(names), invert = FALSE) {


### PR DESCRIPTION
Setting numeric columns alignment to `dt-right` should respect users' option.

This issue arises from the updating version of `DataTable` https://github.com/rstudio/DT/commit/9235453ef3825525eb4dd861ce4e4de620bad633

It seems like in the old version, `DataTable` only uses the first `className` for multiple defined columns. While in the new version, it will attach multiple `className` to the same column in order and causes the issue.

closes #476 