### PR TITLE
Fix error checking when attempting to use Crosstalk in server mode

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -70,7 +70,7 @@ renderDataTable = function(expr, server = TRUE, env = parent.frame(), quoted = F
 
     # in the server mode, we should not store the full data in JSON
     if (server && !is.null(instance[['x']])) {
-      if (!is.null(instance$x$options$crosstalkOptions$group)) {
+      if (!is.null(instance$x$crosstalkOptions$group)) {
         stop("Crosstalk only works with DT client mode: DT::renderDataTable({...}, server=FALSE)")
       }
 


### PR DESCRIPTION
This was left out when Crosstalk options were moved to `params` in https://github.com/rstudio/DT/commit/893708ca10def9cfe0733598019b62a8230fc52b