### PR TITLE
method updateSearch respects regex and case settings

### DIFF
--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1057,7 +1057,14 @@ HTMLWidgets.widget({
           return;
         }
         $(td).find('input').first().val(v);
-        table.column(i).search(v);
+
+        var regex = false, ci = true;
+        if (options.search) {
+          regex = options.search.regex,
+          ci = options.search.caseInsensitive !== false;
+        }
+
+        table.column(i).search(v, regex, !regex, ci);
       });
       table.draw();
     }


### PR DESCRIPTION
Currently, updateSearch ignores the regex settings. E.g. in the Shiny App below after a click on the button "search" we get an empty table.

Note: The fix isn't that nice as I simply copied some code from above. You might want to refactor it into a function. As I don't know much Javascript I didn't really want to try it myself.

```
library(shiny)
library(DT)


shinyApp(
  ui = fluidPage(
    DT::dataTableOutput("tbl"),
    actionButton("but", "search")
  ),
  
  server = function(input, output, session) {
    output$tbl <- DT::renderDataTable(
      data.frame(a = month.name, stringsAsFactors = FALSE),
      options = list(search = list(regex = TRUE)),
      filter = list(position = "bottom")
    )
    
    observeEvent(input$but, {
      DT::updateSearch(DT::dataTableProxy("tbl"), keywords = list(columns = "Jan|Feb"))
    })
  }
)
```