### PR TITLE
Respond to plotly's persistent selection mode

### DIFF
--- a/inst/examples/DT-crosstalk/plotly-persist.R
+++ b/inst/examples/DT-crosstalk/plotly-persist.R
@@ -1,0 +1,15 @@
+library(plotly)
+library(crosstalk)
+library(DT)
+
+m <- SharedData$new(mtcars)
+bscols(
+  plot_ly(m, x = ~wt, y = ~mpg) %>%
+    add_markers() %>%
+    config(displayModeBar = FALSE) %>%
+    layout(
+      title = "Hold shift while clicking \n markers for persistent selection",
+      margin = list(t = 60)
+    ),
+  datatable(m)
+)

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -320,7 +320,12 @@ HTMLWidgets.widget({
         }
 
         if (e.sender !== instance.ctselectHandle && e.value && e.value.length) {
-          $table[0].ctselect = keysToMatches(e.value);
+          var ctOpts = crosstalk.var("plotlyCrosstalkOpts").get() || {};
+          if (ctOpts.persistent === true) {
+           $table[0].ctselect = [].concat($table[0].ctselect, keysToMatches(e.value));
+          } else {
+            $table[0].ctselect = keysToMatches(e.value);
+          }
           table.draw();
         } else {
           if ($table[0].ctselect) {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -322,7 +322,7 @@ HTMLWidgets.widget({
         if (e.sender !== instance.ctselectHandle && e.value && e.value.length) {
           var ctOpts = crosstalk.var("plotlyCrosstalkOpts").get() || {};
           if (ctOpts.persistent === true) {
-           $table[0].ctselect = [].concat($table[0].ctselect, keysToMatches(e.value));
+            $table[0].ctselect = [].concat($table[0].ctselect, keysToMatches(e.value));
           } else {
             $table[0].ctselect = keysToMatches(e.value);
           }


### PR DESCRIPTION
This adds the ability to perform persistent selection with plotly (similar to how https://github.com/rstudio/leaflet/pull/346 does for leaflet).

It would be ideal to have rows somehow reflect [plotly's selection color](https://github.com/rstudio/leaflet/pull/346/files#diff-8e0e6e242b99825df0596336e5ad4d7aR876), let me know if have any ideas how best to go about that (e.g. color the text or highlight the row?)

![dt](https://user-images.githubusercontent.com/1365941/36005239-4d045ade-0cfc-11e8-843b-cc7f48a5d776.gif)
