### PR TITLE
fix #495

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4
+Version: 0.4.1
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# CHANGES IN DT VERSION 0.5
+
+## BUG FIXES
+
+- `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495)
+
 # CHANGES IN DT VERSION 0.4
 
 ## BUG FIXES

--- a/R/format.R
+++ b/R/format.R
@@ -231,6 +231,17 @@ tplStyle = function(cols, valueCols, target, styles, ...) {
   )
 }
 
+jsValues = function(x) {
+  if (inherits(x, c("POSIXt", "POSIXct", "POSIXlt"))) {
+    sprintf("'%s'", format(x, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"))
+  } else if (inherits(x, "Date")) {
+    sprintf("'%s'", format(x, "%Y-%m-%d"))
+  } else {
+    x
+  }
+}
+
+
 #' Conditional CSS styles
 #'
 #' A few helper functions for the \code{\link{formatStyle}()} function to
@@ -267,7 +278,7 @@ styleInterval = function(cuts, values) {
   if (!all(cuts == sort(cuts))) stop("'cuts' must be sorted increasingly")
   js = "isNaN(parseFloat(value)) ? '' : "  # missing or non-numeric values in data
   for (i in seq_len(n)) {
-    js = paste0(js, sprintf('value <= %s ? %s : ', cuts[i], values[i]))
+    js = paste0(js, sprintf('value <= %s ? %s : ', jsValues(cuts[i]), values[i]))
   }
   JS(paste0(js, values[n + 1]))
 }
@@ -283,7 +294,7 @@ styleEqual = function(levels, values) {
   if (n == 0) return("''")
   levels2 = levels
   if (is.character(levels)) levels2 = gsub("'", "\\'", levels)
-  levels2 = sprintf("'%s'", levels2)
+  if (is.Date(levels2)) levels2 = jsValues(levels2) else levels2 = sprintf("'%s'", levels2)
   levels2[is.na(levels)] = 'null'
   js = ''
   for (i in seq_len(n)) {


### PR DESCRIPTION
`styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values.

Closes #495 

# Example

```r
library(DT)
dates <- as.Date(c("2018-01-01","2019-01-01"))
times <- as.POSIXct(c("2018-01-01 15:00", "2018-01-01 20:00"), tz = "UTC")
tbl <- 
  data.frame(
    Date = dates,
    Date2 = dates,
    Time = times,
    Time2 = times,
    Time3 = times,
    Time4 = times
  )
tbl %>%
  datatable() %>%
  formatStyle(columns = c("Date", "Date2"),
              backgroundColor = styleInterval(as.Date("2018-02-02"), c("#FB717E", "#89EC6A"))) %>%
  formatStyle(columns = c("Time", "Time2"),
              backgroundColor = styleInterval(as.POSIXct(c("2018-01-01 18:00"), tz = "UTC"), c("#FB717E", "#89EC6A"))) %>%
  formatStyle(columns = c("Time3"),
              backgroundColor = styleInterval(as.POSIXct(c("2018-01-02 02:00"), tz = "PRC"), c("#FB717E", "#89EC6A"))) %>%
  formatStyle(columns = c("Time4"),
              backgroundColor = styleEqual(times, c("#FB717E", "#89EC6A"))) %>%
  formatDate(columns = c("Date2", "Time2"), c("toDateString", "toTimeString"))
```
