### PR TITLE
extended editor capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ large.txt
 inst/examples/random.R
 .*.Rnb.cached
 revdep/
+inst/.DS_Store
+.DS_Store
+inst/examples/DT-edit/app.R


### PR DESCRIPTION
I extended the editor capabilities, so distinct columns can be marked as editable and the type of the editor can be switched between a text input and a select input.
The editor is enabled by using `editable = TRUE` option for the data tables init. The additional attributes `editType` and `editAttribs` define the type of the editor and the editor attributes. They are set up as follows: 
```options = list(editable = T,
      editType = list("1" = "text", "2" = "text", "3" = "text", "4" = "text", "5" = "select"),
      editAttribs = list("1" = list(placeholder = "Length"), "2" = list(placeholder = "Width"),
                         "3" = list(placeholder = "Length"), "4" = list(placeholder = "Width"),
                         "5" = list(options = c("setosa", "versicolor", "virginica")))
    )
```
The names in the list specify the target column, "text" specifies a text input and "select" specifies a select input. Currently, the only available option for a text input is the placeholder and for a select input the selectable options.

Furthermore the editor now offers reactivity to the keys enter, escape and tab.

Hopefully, this commit fixes #493 

For testing is used the following code:

```
library(shiny)
library(DT)
shinyApp(
  ui = fluidPage(
    title = 'Double-click to edit table cells',
    titlePanel('Double-click to edit table cells'),
    DTOutput('x1')
  ),
  server = function(input, output, session) {
    d1 = iris

    output$x1 = renderDT(d1, selection = 'none', options = list(editable = T,
      editType = list("1" = "text", "2" = "text", "3" = "text", "4" = "text", "5" = "select"),
      editAttribs = list("1" = list(placeholder = "Length"), "2" = list(placeholder = "Width"),
                         "3" = list(placeholder = "Length"), "4" = list(placeholder = "Width"),
                         "5" = list(options = c("setosa", "versicolor", "virginica")))
    ))

    proxy1 = dataTableProxy('x1')

    observeEvent(input$x1_cell_edit, {
      info = input$x1_cell_edit
      str(info)
      i = info$row
      j = info$col
      v = info$value
      d1[i, j] <<- DT::coerceValue(v, d1[i, j])
      replaceData(proxy1, d1, resetPaging = FALSE)
    })
  }
)
```

PS: Please excuse my bad javascript, I'm both new to GitHub and javascript.