### PR TITLE
classNameDefinedColumns() now identifies negative and "_all" targets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495)
 
+- `dt-right` class will no longer be added to numeric headers unexpectly. (thanks, @shrektan @carlganz @vnijs, #512 #511 #476)
+
 # CHANGES IN DT VERSION 0.4
 
 ## BUG FIXES

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -132,7 +132,7 @@ datatable = function(
   if (length(numc)) {
     # if the `className` of the column has already been defined by the user,
     # we should not touch it
-    undefined_numc = setdiff(numc - 1, classNameDefinedColumns(options))
+    undefined_numc = setdiff(numc - 1, classNameDefinedColumns(options, ncol(data)))
     if (length(undefined_numc)) options = appendColumnDefs(
       options, list(className = 'dt-right', targets = undefined_numc)
     )
@@ -286,12 +286,21 @@ appendColumnDefs = function(options, def) {
   options
 }
 
-classNameDefinedColumns = function(options) {
+classNameDefinedColumns = function(options, ncol) {
   defs = options[['columnDefs']]
   cols = integer()
   for (def in defs) {
-    if (!is.null(def[['className']]) && is.numeric(col <- def[['targets']]))
-      cols = c(cols, col)
+    if (!is.null(def[['className']])) {
+      col = def[['targets']]
+      if (is.numeric(col)) {
+        col[col < 0] = col[col < 0] + ncol
+      } else if ("_all" %in% col) {
+        col = seq_len(ncol)
+      } else {
+        col = integer()
+      }
+    }
+    cols = c(cols, col)
   }
   unique(cols)
 }


### PR DESCRIPTION
closes #511 

The fix #476 misses the fact that besides of column indexes, there're [4 kinds](https://datatables.net/reference/option/columnDefs.targets) of `columnDefs.targets` in total.

- [x] 0 or a positive integer - column index counting from the left
- [x]  A negative integer - column index counting from the right
- [ ] A string - class name will be matched on the TH for the column (without a leading .)
- [x] The string "_all" - all columns (i.e. assign a default)

This PR is meant to handle all the rest cases. **However, for case 3, I can't reproduce the effect in the first place.** What I mean is explained by the following example:

```r
DT::datatable(
  data.frame(a = 1, b = 2, c = 3, d = 4),
  options = list(
    columnDefs = list(
      list(className = "dt_center", targets = "a") 
      # it should have set "a" column center alignment, but it didn't
    )
  )
)
```

For 1, 2 and 4 cases, they are correctly handled now.

```r
DT::datatable(
  data.frame(a = 1, b = 2, c = 3, d = 4),
  options = list(
    columnDefs = list(
      list(className = "dt-center", targets = "_all")
    )
  )
)

DT::datatable(
  data.frame(a = 1, b = 2, c = 3, d = 4),
  options = list(
    columnDefs = list(
      list(className = "dt-center", targets = c(-1, 2))
    )
  )
)

```