### PR TITLE
Respect htmlwidgets.TOJSON_ARGS in server-side processing mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,11 @@
 
 ## BUG FIXES
 
-- `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495)
+- `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495).
 
 - The `dt-right` class will no longer be added to numeric headers unexpectedly (thanks, @shrektan @carlganz @vnijs, #514 #512 #511 #476).
+
+- The printing values of `NA` and `Inf` can be controlled by `getOption('htmlwidgets.TOJSON_ARGS')` in the server-side processing mode now. (thanks, @shrektan, #513).
 
 # CHANGES IN DT VERSION 0.4
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -379,7 +379,9 @@ sessionDataURL = function(session, data, id, filter) {
     res = tryCatch(filter(data, params), error = function(e) {
       list(error = as.character(e))
     })
-    httpResponse(200, 'application/json', enc2utf8(toJSON(res, dataframe = 'rows')))
+
+    jsonArgs = c(list(x = res, dataframe = 'rows'), getOption('htmlwidgets.TOJSON_ARGS'))
+    httpResponse(200, 'application/json', enc2utf8(do.call(toJSON, jsonArgs)))
   }
 
   session$registerDataObj(id, data, filterFun)


### PR DESCRIPTION
closes #496 

### example 

```r
library(shiny)

dat <- data.frame(
  a = c(5, 6, NA, Inf, 10, 100),
  b = c(letters[1:4], NA, NA),
  c = factor(c(letters[1:4], NA, NA)),
  stringsAsFactors = FALSE
)

shinyApp(
  ui = fluidPage(
    radioButtons("na_inf", "na_inf", c("null", "string"), inline = TRUE),
    fluidRow(
      column(
        6,
        h3("client mode"),
        DT::dataTableOutput("client_dt")
      ),
      column(
        6,
        h3("server mode"),
        DT::dataTableOutput("server_dt")
      )
    )
  ),
  server = function(input,output){
    observe(
      options("htmlwidgets.TOJSON_ARGS" = list(na = input$na_inf))
    )
    output$client_dt <- DT::renderDataTable({
      input$na_inf
      DT::datatable(head(dat))
    }, server = FALSE)
    output$server_dt <- DT::renderDataTable({
      input$na_inf
      DT::datatable(head(dat))
    }, server = TRUE)
  },
  options = list(port = 6815)
)
```