### PR TITLE
Fix the issue that the first header is still right aligned

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495)
 
-- The `dt-right` class will no longer be added to numeric headers unexpectedly (thanks, @shrektan @carlganz @vnijs, #512 #511 #476).
+- The `dt-right` class will no longer be added to numeric headers unexpectedly (thanks, @shrektan @carlganz @vnijs, #514 #512 #511 #476).
 
 # CHANGES IN DT VERSION 0.4
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -295,7 +295,7 @@ classNameDefinedColumns = function(options, ncol) {
       if (is.numeric(col)) {
         col[col < 0] = col[col < 0] + ncol
       } else if ("_all" %in% col) {
-        col = seq_len(ncol)
+        col = seq_len(ncol) - 1
       } else {
         col = integer()
       }


### PR DESCRIPTION
Fix the issue that the first header is still right aligned when the data has no row name and the `target` is set to `"_all"`. It's a patch for #512 .

### some examples

```r
DT::datatable(
  data.frame(a = 1, b = 2, c = 3, d = 4),
  options = list(
    columnDefs = list(
      list(className = "dt-center", targets = "_all")
    )
  )
)

DT::datatable(
  data.frame(a = 1, b = 2, c = 3, d = 4),
  options = list(
    columnDefs = list(
      list(className = "dt-center", targets = c(-1, 2))
    )
  )
)


DT::datatable(
  sapply(iris[,1:3], as.integer),
  options = list(
    columnDefs = list(
      list(className = "dt-center", targets = "_all")
    )
  )
)


DT::datatable(
  iris[,1:3], rownames = FALSE,
  options = list(
    columnDefs = list(
      list(className = "dt-center", targets = "_all")
    )
  )
)

```