### PR TITLE
fix#515

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.4
+Version: 0.4.5
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - The printing values of `NA` and `Inf` can be controlled by `getOption('htmlwidgets.TOJSON_ARGS')` in the server-side processing mode now. (thanks, @shrektan, #513).
 
+- `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. (thanks, @shrektan @mteixido, #516 #515)
+
 # CHANGES IN DT VERSION 0.4
 
 ## BUG FIXES

--- a/R/format.R
+++ b/R/format.R
@@ -236,6 +236,8 @@ jsValues = function(x) {
     sprintf("'%s'", format(x, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"))
   } else if (inherits(x, "Date")) {
     sprintf("'%s'", format(x, "%Y-%m-%d"))
+  } else if (is.numeric(x)) {
+    sprintf("%f", x)
   } else {
     x
   }
@@ -294,7 +296,7 @@ styleEqual = function(levels, values) {
   if (n == 0) return("''")
   levels2 = levels
   if (is.character(levels)) levels2 = gsub("'", "\\'", levels)
-  if (is.Date(levels2)) levels2 = jsValues(levels2) else levels2 = sprintf("'%s'", levels2)
+  levels2 = if (is.Date(levels2) || is.numeric(levels2)) jsValues(levels2) else sprintf("'%s'", levels2)
   levels2[is.na(levels)] = 'null'
   js = ''
   for (i in seq_len(n)) {
@@ -318,7 +320,7 @@ styleColorBar = function(data, color, angle=90) {
   rg = range(data, na.rm = TRUE, finite = TRUE)
   r1 = rg[1]; r2 = rg[2]; r = r2 - r1
   JS(sprintf(
-    "isNaN(parseFloat(value)) || value <= %s ? '' : 'linear-gradient(%sdeg, transparent ' + (%s - value)/%s * 100 + '%%, %s ' + (%s - value)/%s * 100 + '%%)'",
+    "isNaN(parseFloat(value)) || value <= %f ? '' : 'linear-gradient(%fdeg, transparent ' + (%f - value)/%f * 100 + '%%, %s ' + (%f - value)/%f * 100 + '%%)'",
     r1, angle, r2, r, color, r2, r
   ))
 }


### PR DESCRIPTION
`styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. 

closes #515 

### Example

```r
options(OutDec=',')
datatable(iris) %>% 
  formatStyle(1,color=styleInterval(c(4.9),c('green','red'))) %>%
  formatStyle(2,color=styleEqual(c(3.1, 3.2),c('green','red'))) %>%
  formatStyle(
    'Petal.Length',
    background = styleColorBar(iris$Petal.Length, 'grey'),
    backgroundSize = '100% 90%',
    backgroundRepeat = 'no-repeat',
    backgroundPosition = 'center'
  )
```