### PR TITLE
Improve the format of the filter of `Date` / `Datetime` columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.5
+Version: 0.4.6
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 
 ## NEW FEATURES
 
-- The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content. (thanks, @shrektan, #522 #241)
+- The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content if `formatDate()` is applied on these columns (thanks, @shrektan, #522 #241).
 
 # CHANGES IN DT VERSION 0.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 - `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. (thanks, @shrektan @mteixido, #516 #515)
 
+## NEW FEATURES
+
+- The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content. (thanks, @shrektan, #522 #241)
+
 # CHANGES IN DT VERSION 0.4
 
 ## BUG FIXES

--- a/R/format.R
+++ b/R/format.R
@@ -111,7 +111,7 @@ formatDate = function(table, columns, method = 'toDateString', params = NULL) {
     if (is.null(params)) params = list()
     cols = as.character(name2int(columns, colnames, rownames))
     x$filterDateFmt = as.list(x$filterDateFmt)
-    for (col in cols) x$options$filterDateFmt[[col]] = list(
+    for (col in cols) x$filterDateFmt[[col]] = list(
       method = method, params = toJSON(params)
     )
     table$x = x

--- a/R/format.R
+++ b/R/format.R
@@ -110,7 +110,7 @@ formatDate = function(table, columns, method = 'toDateString', params = NULL) {
     rownames = base::attr(x, 'rownames', exact = TRUE)
     if (is.null(params)) params = list()
     cols = as.character(name2int(columns, colnames, rownames))
-    if (is.null(x$options$filterDateFmt)) x$options$filterDateFmt = list()
+    x$filterDateFmt = as.list(x$filterDateFmt)
     for (col in cols) x$options$filterDateFmt[[col]] = list(
       method = method, params = toJSON(params)
     )

--- a/R/format.R
+++ b/R/format.R
@@ -109,7 +109,7 @@ formatDate = function(table, columns, method = 'toDateString', params = NULL) {
     colnames = base::attr(x, 'colnames', exact = TRUE)
     rownames = base::attr(x, 'rownames', exact = TRUE)
     if (is.null(params)) params = list()
-    cols = as.character(name2int(columns, colnames, rownames))
+    cols = sprintf("%d", name2int(columns, colnames, rownames))
     x$filterDateFmt = as.list(x$filterDateFmt)
     for (col in cols) x$filterDateFmt[[col]] = list(
       method = method, params = toJSON(params)

--- a/R/format.R
+++ b/R/format.R
@@ -103,6 +103,21 @@ formatSignif = function(
 #'   \code{params = list('ko-KR', list(year = 'numeric', month = 'long', day =
 #'   'numeric'))}
 formatDate = function(table, columns, method = 'toDateString', params = NULL) {
+  x = table$x
+  if (x$filter != 'none') {
+    if (inherits(columns, 'formula')) columns = all.vars(columns)
+    colnames = base::attr(x, 'colnames', exact = TRUE)
+    rownames = base::attr(x, 'rownames', exact = TRUE)
+    if (is.null(params)) params = list()
+    cols = as.character(name2int(columns, colnames, rownames))
+    if (is.null(x$options$filterDateFmt)) x$options$filterDateFmt = list()
+    for (col in cols) x$options$filterDateFmt[[col]] = list(
+      method = method, params = toJSON(params)
+    )
+    table$x = x
+  }
+  # the code above is used to ensure the date(time) filter displays the same format or
+  # timezone as the column value
   formatColumns(table, columns, tplDate, method, params)
 }
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -563,7 +563,10 @@ HTMLWidgets.widget({
             }
             r1  = t1; r2 = t2;
           })();
-          $span1.text(formatDate(r1, false)); $span2.text(formatDate(r2, false));
+          var updateSliderText = function(v1, v2) {
+            $span1.text(formatDate(v1, false)); $span2.text(formatDate(v2, false));
+          };
+          updateSliderText(r1, r2);
           var updateSlider = function(e) {
             var val = filter.val();
             // turn off filter if in full range
@@ -575,7 +578,7 @@ HTMLWidgets.widget({
             } else {
               $input.attr('title', '').val('');
             }
-            $span1.text(formatDate(val[0], false)); $span2.text(formatDate(val[1], false));
+            updateSliderText(val[0], val[1]);
             if (e.type === 'slide') return;  // no searching when sliding only
             if (server) {
               table.column(i).search($td.data('filter') ? ival : '').draw();

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -563,7 +563,7 @@ HTMLWidgets.widget({
             }
             r1  = t1; r2 = t2;
           })();
-          $span1.text(formatDate(r1)); $span2.text(formatDate(r2));
+          $span1.text(formatDate(r1, false)); $span2.text(formatDate(r2, false));
           var updateSlider = function(e) {
             var val = filter.val();
             // turn off filter if in full range

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -520,18 +520,14 @@ HTMLWidgets.widget({
               filter.val(v);
             }
           });
-          var formatDate = function(d, toServer) {
+          var formatDate = function(d, isoFmt = false) {
             d = scaleBack(d, scale);
             if (type === 'number') return d;
             if (type === 'integer') return parseInt(d);
             var x = new Date(+d);
             var fmt = undefined;
-            if ('filterDateFmt' in options) {
-              fmt = options.filterDateFmt[i];
-            }
-            if (!toServer && fmt !== undefined) {
-              return x[fmt.method].apply(x, fmt.params);
-            }
+            if ('filterDateFmt' in options) fmt = options.filterDateFmt[i];
+            if (!isoFmt && fmt !== undefined) return x[fmt.method].apply(x, fmt.params);
             if (type === 'date') {
               var pad0 = function(x) {
                 return ('0' + x).substr(-2, 2);
@@ -568,23 +564,22 @@ HTMLWidgets.widget({
             }
             r1  = t1; r2 = t2;
           })();
-          $span1.text(formatDate(r1, false)); $span2.text(formatDate(r2, false));
+          $span1.text(formatDate(r1)); $span2.text(formatDate(r2));
           var updateSlider = function(e) {
             var val = filter.val();
             // turn off filter if in full range
             $td.data('filter', val[0] > r1 || val[1] < r2);
-            var v1 = formatDate(val[0]), v2 = formatDate(val[1]), ival;
+            var ival;
             if ($td.data('filter')) {
-              ival = v1 + ' ... ' + v2;
+              ival = formatDate(val[0], true) + ' ... ' + formatDate(val[1], true);
               $input.attr('title', ival).val(ival).trigger('input');
             } else {
               $input.attr('title', '').val('');
             }
-            $span1.text(v1); $span2.text(v2);
+            $span1.text(formatDate(val[0])); $span2.text(formatDate(val[1]));
             if (e.type === 'slide') return;  // no searching when sliding only
             if (server) {
-              v1 = formatDate(val[0], true); v2 = formatDate(val[1], true);
-              ival = v1 + ' ... ' + v2;
+              ival = formatDate(val[0], true) + ' ... ' + formatDate(val[1], true);
               table.column(i).search($td.data('filter') ? ival : '').draw();
               return;
             }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -525,6 +525,13 @@ HTMLWidgets.widget({
             if (type === 'number') return d;
             if (type === 'integer') return parseInt(d);
             var x = new Date(+d);
+            var fmt = undefined;
+            if ('filterDateFmt' in options) {
+              fmt = options.filterDateFmt[i];
+            }
+            if (fmt !== undefined) {
+              return x[fmt.method].apply(x, fmt.params);
+            }
             if (type === 'date') {
               var pad0 = function(x) {
                 return ('0' + x).substr(-2, 2);

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -520,14 +520,13 @@ HTMLWidgets.widget({
               filter.val(v);
             }
           });
-          var formatDate = function(d, isoFmt = false) {
+          var formatDate = function(d, isoFmt) {
             d = scaleBack(d, scale);
             if (type === 'number') return d;
             if (type === 'integer') return parseInt(d);
             var x = new Date(+d);
-            var fmt = undefined;
-            if ('filterDateFmt' in options) fmt = options.filterDateFmt[i];
-            if (!isoFmt && fmt !== undefined) return x[fmt.method].apply(x, fmt.params);
+            var fmt = ('filterDateFmt' in data) ? data.filterDateFmt[i] : undefined;
+            if (fmt !== undefined && isoFmt === false) return x[fmt.method].apply(x, fmt.params);
             if (type === 'date') {
               var pad0 = function(x) {
                 return ('0' + x).substr(-2, 2);
@@ -569,17 +568,16 @@ HTMLWidgets.widget({
             var val = filter.val();
             // turn off filter if in full range
             $td.data('filter', val[0] > r1 || val[1] < r2);
-            var ival;
+            var v1 = formatDate(val[0]), v2 = formatDate(val[1]), ival;
             if ($td.data('filter')) {
-              ival = formatDate(val[0], true) + ' ... ' + formatDate(val[1], true);
+              ival = v1 + ' ... ' + v2;
               $input.attr('title', ival).val(ival).trigger('input');
             } else {
               $input.attr('title', '').val('');
             }
-            $span1.text(formatDate(val[0])); $span2.text(formatDate(val[1]));
+            $span1.text(formatDate(val[0], false)); $span2.text(formatDate(val[1], false));
             if (e.type === 'slide') return;  // no searching when sliding only
             if (server) {
-              ival = formatDate(val[0], true) + ' ... ' + formatDate(val[1], true);
               table.column(i).search($td.data('filter') ? ival : '').draw();
               return;
             }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -520,7 +520,7 @@ HTMLWidgets.widget({
               filter.val(v);
             }
           });
-          var formatDate = function(d) {
+          var formatDate = function(d, toServer) {
             d = scaleBack(d, scale);
             if (type === 'number') return d;
             if (type === 'integer') return parseInt(d);
@@ -529,7 +529,7 @@ HTMLWidgets.widget({
             if ('filterDateFmt' in options) {
               fmt = options.filterDateFmt[i];
             }
-            if (fmt !== undefined) {
+            if (!toServer && fmt !== undefined) {
               return x[fmt.method].apply(x, fmt.params);
             }
             if (type === 'date') {
@@ -568,7 +568,7 @@ HTMLWidgets.widget({
             }
             r1  = t1; r2 = t2;
           })();
-          $span1.text(formatDate(r1)); $span2.text(formatDate(r2));
+          $span1.text(formatDate(r1, false)); $span2.text(formatDate(r2, false));
           var updateSlider = function(e) {
             var val = filter.val();
             // turn off filter if in full range
@@ -583,6 +583,8 @@ HTMLWidgets.widget({
             $span1.text(v1); $span2.text(v2);
             if (e.type === 'slide') return;  // no searching when sliding only
             if (server) {
+              v1 = formatDate(val[0], true); v2 = formatDate(val[1], true);
+              ival = v1 + ' ... ' + v2;
               table.column(i).search($td.data('filter') ? ival : '').draw();
               return;
             }


### PR DESCRIPTION
Closes #241 

Improve the format of the filter of `Date` / `Datetime` columns. It will display the same format and timezone as the column content.

~~At the time of writing, the PR is unfinished because it doesn't work for server-side processing mode.~~ DONE, it now works properly with server-side processing mode.

# TODO

- [x] ensure the filter returns correct contents in server-side processing mode.

# Example 

```r
library(DT)
library(shiny)

df <- data.frame(
  time = lubridate::ymd_hm(201801011000) + lubridate::dminutes(0:120),
  time2 = lubridate::ymd_hm(201801011000) + lubridate::dminutes(0:120),
  date = lubridate::ymd(20180101) + lubridate::ddays(0:120),
  date2 = lubridate::ymd(20180101) + lubridate::ddays(0:120)
)

ui <- fluidPage(
  h3("server = TRUE"),
  DT::DTOutput("tbl1"),
  hr(),
  h3("server = FALSE"),
  DT::DTOutput("tbl2"),
  hr(),
  h3("without `formatDate()`"),
  DT::DTOutput("tbl0")
)

server <- function(input, output, session) {
  output$tbl0 <- DT::renderDT({
    datatable(df, filter = "top")
  })
  output$tbl1 <- DT::renderDT({
    datatable(df, filter = "top") %>% 
      formatDate(c("time"), method = 'toLocaleString', params = list("en-US", list(timeZone = "Asia/Shanghai", hour12 = FALSE))) %>%
      formatDate(c("time2"), method = 'toLocaleString', params = list("se", list(timeZone = "UTC", hour12 = FALSE))) %>%
      formatDate(c("date"), method = 'toLocaleDateString', params = list("en-US")) %>%
      formatDate(c("date2"), method = 'toLocaleDateString')
  }, server = TRUE)
  output$tbl2 <- DT::renderDT({
    datatable(df, filter = "top") %>% 
      formatDate(c("time"), method = 'toLocaleString', params = list("en-US", list(timeZone = "Asia/Shanghai", hour12 = FALSE))) %>%
      formatDate(c("time2"), method = 'toLocaleString', params = list("se", list(timeZone = "UTC", hour12 = FALSE))) %>%
      formatDate(c("date"), method = 'toLocaleDateString', params = list("en-US")) %>%
      formatDate(c("date2"), method = 'toLocaleDateString')
  }, server = FALSE)
}

shinyApp(ui, server)

``` 