### PR TITLE
fix selectRows/Columns()'s weird behavior for certain inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.6
+Version: 0.4.7
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 - `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. (thanks, @shrektan @mteixido, #516 #515)
 
-- fix a bug that `selectRows()` and `selectColumns()` behaves erratically for scalar inputs or character inputs. (thanks, @shrektan #528)
+- Fixed a bug that `selectRows()` and `selectColumns()` behave erratically for scalar inputs or character inputs (thanks, @shrektan #528).
 
 ## NEW FEATURES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. (thanks, @shrektan @mteixido, #516 #515)
 
+- fix a bug that `selectRows()` and `selectColumns()` won't work (UI side) with the scalar input. (thanks, @shrektan #528)
+
 ## NEW FEATURES
 
 - The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content if `formatDate()` is applied on these columns (thanks, @shrektan, #522 #241).

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 - `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. (thanks, @shrektan @mteixido, #516 #515)
 
-- fix a bug that `selectRows()` and `selectColumns()` won't work (UI side) with the scalar input. (thanks, @shrektan #528)
+- fix a bug that `selectRows()` and `selectColumns()` behaves erratically for scalar inputs or character inputs. (thanks, @shrektan #528)
 
 ## NEW FEATURES
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -167,13 +167,13 @@ dataTableProxy = function(
 #' @rdname proxy
 #' @export
 selectRows = function(proxy, selected) {
-  invokeRemote(proxy, 'selectRows', list(I_null(selected)))
+  invokeRemote(proxy, 'selectRows', list(I_null(as.integer(selected))))
 }
 
 #' @rdname proxy
 #' @export
 selectColumns = function(proxy, selected) {
-  invokeRemote(proxy, 'selectColumns', list(I_null(selected)))
+  invokeRemote(proxy, 'selectColumns', list(I_null(as.integer(selected))))
 }
 
 I_null = function(x) if (is.null(x)) list() else x

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -904,7 +904,7 @@ HTMLWidgets.widget({
         // server-side tables, we have to *real* row indices are in `selected1`
         if (server) table.on('draw.dt', selectRows);
         methods.selectRows = function(selected) {
-          selected1 = selected ? $.isArray(selected) ? selected : [selected] : [];
+          selected1 = $.makeArray(selected);
           selectRows();
           changeInput('rows_selected', selected1);
         }
@@ -938,7 +938,7 @@ HTMLWidgets.widget({
         selectCols();  // in case users have specified pre-selected columns
         if (server) table.on('draw.dt', selectCols);
         methods.selectColumns = function(selected) {
-          selected2 = selected ? $.isArray(selected) ? selected : [selected] : [];
+          selected2 = $.makeArray(selected);
           selectCols();
           changeInput('columns_selected', selected2);
         }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -904,7 +904,7 @@ HTMLWidgets.widget({
         // server-side tables, we have to *real* row indices are in `selected1`
         if (server) table.on('draw.dt', selectRows);
         methods.selectRows = function(selected) {
-          selected1 = selected ? selected : [];
+          selected1 = selected ? $.isArray(selected) ? selected : [selected] : [];
           selectRows();
           changeInput('rows_selected', selected1);
         }
@@ -938,7 +938,7 @@ HTMLWidgets.widget({
         selectCols();  // in case users have specified pre-selected columns
         if (server) table.on('draw.dt', selectCols);
         methods.selectColumns = function(selected) {
-          selected2 = selected ? selected : [];
+          selected2 = selected ? $.isArray(selected) ? selected : [selected] : [];
           selectCols();
           changeInput('columns_selected', selected2);
         }


### PR DESCRIPTION
This PR fixes a bug that `selectRows()` and `selectColumns()` doesn't work (or works partially and inconsistently) for certain inputs, such as scalar inputs or character inputs (e.g., "3", "5").

You can try:

- select only one number and click __numeric submit__ and __string submit__ respectively.
- select only two or more numbers and click __numeric submit__ and __string submit__ respectively.

You will find that something like only the column gets selected or `tbl_selected_rows` gets updated (__be aware of the top line of the app where I put the text info__) but in the UI it's not.

# Example Code

```r
library(DT)
library(shiny)
ui <- fluidPage(
  textOutput("info"),
  actionButton("clear", "clear all"),
  inputPanel(
    selectInput("rows_tbl", "rows", 1:10, multiple = TRUE),
    selectInput("cols_tbl", "cols", 1:5, multiple = TRUE),
    actionButton("submit1_tbl", "numeric submit"),
    actionButton("submit2_tbl", "string submit")
  ),
  fluidRow(
    column(
      6,
      h1("server = TRUE"),
      DTOutput("tbl1")
    ),
    column(
      6,
      h1("server = FALSE"),
      DTOutput("tbl2")
    )
  )
)
server <- function(input, output, session) {
  output$tbl1 <- renderDT(
    iris, server = TRUE, selection = list(target = 'row+column')
  )
  output$tbl2 <- renderDT(
    iris, server = FALSE, selection = list(target = 'row+column')
  )
  proxy1 <- dataTableProxy('tbl1')
  proxy2 <- dataTableProxy('tbl2')
  output$info <- renderPrint({
    list(rows1 = input$tbl1_rows_selected, columns1 = input$tbl1_columns_selected,
         rows2 = input$tbl2_rows_selected, columns2 = input$tbl2_columns_selected)
  })
  observeEvent(input$submit1_tbl, {
    proxy1 %>% selectRows(as.numeric(input$rows_tbl)) %>% selectColumns(as.numeric(input$cols_tbl))
    proxy2 %>% selectRows(as.numeric(input$rows_tbl)) %>% selectColumns(as.numeric(input$cols_tbl))
  })
  observeEvent(input$submit2_tbl, {
    proxy1 %>% selectRows(input$rows_tbl) %>% selectColumns(input$cols_tbl)
    proxy2 %>% selectRows(input$rows_tbl) %>% selectColumns(input$cols_tbl)
  })
  observeEvent(input$clear, {
    updateSelectInput(session, "rows_tbl", selected = "")
    updateSelectInput(session, "cols_tbl", selected = "")
    proxy1 %>% selectRows(NULL) %>% selectColumns(NULL)
    proxy2 %>% selectRows(NULL) %>% selectColumns(NULL)
  })
}
shinyApp(ui, server, options = list(port = 38888))
```

# Some snapshot 

## Before the PR

### numeric submit

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/8368933/38820276-047f04c2-41d0-11e8-86ca-44a721f09005.png">

### string submit

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/8368933/38820292-10679952-41d0-11e8-9cad-2455b8078dad.png">

## After the PR

### numeric submit

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/8368933/38820351-3e0fd036-41d0-11e8-80fd-16e79dd5846c.png">


### string submit

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/8368933/38820375-49c5d3f8-41d0-11e8-8991-9405b5c25f51.png">

