### PR TITLE
the server mode supports sub data.frame in its column now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.7
+Version: 0.4.8
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - Fixed a bug that `selectRows()` and `selectColumns()` behave erratically for scalar inputs or character inputs (thanks, @shrektan #528).
 
+- The server-side processing mode now supports data with sub-`data.frame` in its columns. (thanks, @shrektan, #530 #525)
+
 ## NEW FEATURES
 
 - The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content if `formatDate()` is applied on these columns (thanks, @shrektan, #522 #241).

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,11 @@
 
 - The printing values of `NA` and `Inf` can be controlled by `getOption('htmlwidgets.TOJSON_ARGS')` in the server-side processing mode now. (thanks, @shrektan, #513).
 
-- `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')`. (thanks, @shrektan @mteixido, #516 #515)
+- `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')` (thanks, @shrektan @mteixido, #516 #515).
 
 - Fixed a bug that `selectRows()` and `selectColumns()` behave erratically for scalar inputs or character inputs (thanks, @shrektan #528).
 
-- The server-side processing mode now supports data with sub-`data.frame` in its columns. (thanks, @shrektan, #530 #525)
+- The server-side processing mode now supports data with nested `data.frame`s in its columns (thanks, @shrektan, #530 #525).
 
 ## NEW FEATURES
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -554,7 +554,7 @@ cleanDataFrame = function(x) {
     xj = unname(xj)  # remove names
     dim(xj) = NULL  # drop dimensions
     if (is.table(xj)) xj = c(xj)  # drop the table class
-    x[, j] = xj
+    x[[j]] = xj
   }
   unname(x)
 }


### PR DESCRIPTION
Closes #525 

Some user wants to implement some heavy customized datatable style, such as in #525, a child table for each row. The current implement `cleanDataFrame()` doesn't support this and leads to a broken datatable in the server-side processing mode. This PR is going to fix this. 


### Example Code

- __Before this PR__ : The browser will throw an error says 

```
DataTables warning: table id=DataTables_Table_0 - Error in `[<-.data.frame`(`*tmp*`, , j, value = list(structure(list(A = c("A", : replacement element 1 is a matrix/data frame of 3 rows, need 2
```

- __After this PR__ : It works.

---

```r
library(data.table)
library(shiny)
library(DT)

dat <- local({
  n <- 6
  DT <- data.table(
    HEADER = '&#9658;',
    A = rep_len(LETTERS, n),
    B = rep_len(1:10, n),
    C = rep_len(c("GRP1", "GRP2"), n)
  )
  DT[, .(D=.(.SD)), by = .(HEADER, C)]
})


callback_js <-
  JS("
var init_tbl = function(id) {
  return '<table id=\"' + id + '\" class=\"display\" width=\"100%\"></table>';
}

var init_datatable = function(id, d) {
  id = '#'+id;
  $(id).DataTable({
    data: d,
    columns: [
    { data: 'A' },
    { data: 'B' }
    ]  
  }).draw();
}
var sub_tbl_id = 0;
table.on('click', 'td.details-control', function() {
  var table = $(this).closest('table');
  var td = $(this);
  var row = $(table).DataTable().row(td.closest('tr'));
if (row.child.isShown()) {
  row.child.hide();
  td.html('&#9658;');
} else {
  sub_tbl_id = sub_tbl_id + 1;
  var id = 'sub_tbl_id_' + sub_tbl_id;
  row.child(init_tbl(id)).show();
  init_datatable(id, row.data()[3]);
  td.html('&#9660;');
}
})
     ")

runApp(list(
  ui = fluidPage(DT::DTOutput("tbl")),
  server = function(input, output) {
    output$tbl <- DT::renderDT({
      datatable(
        dat,
        escape = FALSE,
        options = list(
          columnDefs = list(
            list(orderable = FALSE, className = 'details-control', targets = 1),
            list(visible = FALSE, targets = -1)
          )
        ),
        callback = callback_js
      )
    }, server = TRUE)
  }), port = 33333)

```