### PR TITLE
introduce a new option DT.TOJSON_ARGS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 - The `dt-right` class will no longer be added to numeric headers unexpectedly (thanks, @shrektan @carlganz @vnijs, #514 #512 #511 #476).
 
-- The printing values of `NA` and `Inf` can be controlled by `getOption('htmlwidgets.TOJSON_ARGS')` in the server-side processing mode now. (thanks, @shrektan, #513).
+- The printing values of `NA` and `Inf` can be controlled by `getOption('DT.TOJSON_ARGS')` in the server-side processing mode now. (thanks, @shrektan, #536 #513).
 
 - `styleEqual()`, `styleInterval()` and `styleColorBar()` now generate correct javascript values when `options(OutDec = ',')` (thanks, @shrektan @mteixido, #516 #515).
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -92,7 +92,7 @@ datatable = function(
     if (is.function(options)) options() else options
   )
   params = list()
-  attr(params, "TOJSON_ARGS") <- getOption("DT.TOJSON_ARGS")
+  attr(params, "TOJSON_ARGS") = getOption("DT.TOJSON_ARGS")
 
   if (crosstalk::is.SharedData(data)) {
     params$crosstalkOptions = list(key = data$key(), group = data$groupName())

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -92,6 +92,7 @@ datatable = function(
     if (is.function(options)) options() else options
   )
   params = list()
+  attr(params, "TOJSON_ARGS") <- getOption("DT.TOJSON_ARGS")
 
   if (crosstalk::is.SharedData(data)) {
     params$crosstalkOptions = list(key = data$key(), group = data$groupName())

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -410,7 +410,8 @@ sessionDataURL = function(session, data, id, filter) {
       list(error = as.character(e))
     })
 
-    jsonArgs = c(list(x = res, dataframe = 'rows'), getOption('DT.TOJSON_ARGS'))
+    jsonArgs = c(list(x = res, dataframe = 'rows'),
+                 getOption('DT.TOJSON_ARGS', getOption('htmlwidgets.TOJSON_ARGS')))
     httpResponse(200, 'application/json', enc2utf8(do.call(toJSON, jsonArgs)))
   }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -410,7 +410,7 @@ sessionDataURL = function(session, data, id, filter) {
       list(error = as.character(e))
     })
 
-    jsonArgs = c(list(x = res, dataframe = 'rows'), getOption('htmlwidgets.TOJSON_ARGS'))
+    jsonArgs = c(list(x = res, dataframe = 'rows'), getOption('DT.TOJSON_ARGS'))
     httpResponse(200, 'application/json', enc2utf8(do.call(toJSON, jsonArgs)))
   }
 


### PR DESCRIPTION
Closes #533 

Ref to #513 #496 

## Description

Introduce a new option `DT.TOJSON_ARGS` to control the NA's printing value, mainly.  

**UPDATE** The default value on the server-side processing mode is set to `getOptions("DT.TOJSON_ARGS", getOptions("htmlwidgets.TOJSON_ARGS")` in order to preserve the same behavior as the client mode, on which `htmlwidgets` packages will pick up`htmlwidgets.TOJSON_ARGS` by default.

see https://github.com/ramnathv/htmlwidgets/blob/e3097fa5ff31402f7fce60f8a2e86147a9b983b2/R/utils.R#L31-L32




## Example

```r
library(shiny)

dat <- data.frame(
  a = c(5, 6, NA, Inf, 10, 100),
  b = c(letters[1:4], NA, NA),
  c = factor(c(letters[1:4], NA, NA)),
  stringsAsFactors = FALSE
)

shinyApp(
  ui = fluidPage(
    radioButtons("na_inf", "na_inf", c("no-option", "null", "string"), inline = TRUE),
    verbatimTextOutput("text"),
    fluidRow(
      column(
        6,
        h3("client mode"),
        DT::dataTableOutput("client_dt")
      ),
      column(
        6,
        h3("server mode"),
        DT::dataTableOutput("server_dt")
      )
    )
  ),
  server = function(input,output){
    observe(
      if (req(input$na_inf) == "no-option") {
        if (!is.null(getOption("DT.TOJSON_ARGS"))) options("DT.TOJSON_ARGS" = NULL)
      } else {
        options("DT.TOJSON_ARGS" = list(na = input$na_inf))
      }
    )
    output$text <- renderPrint({
      input$na_inf
      str(getOption("DT.TOJSON_ARGS"))
    })
    output$client_dt <- DT::renderDataTable({
      input$na_inf
      DT::datatable(head(dat))
    }, server = FALSE)
    output$server_dt <- DT::renderDataTable({
      input$na_inf
      DT::datatable(head(dat))
    }, server = TRUE)
  },
  options = list(port = 6815)
)
```