### PR TITLE
`formatDate()` may display dates off by one day when method = "toLocaleDateString"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.9
+Version: 0.4.10
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - The `colReorder` extention now works with the column filters and the server-side processing mode (thanks @shrektan, #532 #531 #160).
 
+- Fix the bug that `formatDate()` may display dates off by one day when method = "toLocaleDateString" (thanks, @shrektan @DevMui, #539 #538).
+
 ## NEW FEATURES
 
 - The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content if `formatDate()` is applied on these columns (thanks, @shrektan, #522 #241).

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -58,7 +58,7 @@ DTWidget.formatDate = function(thiz, row, data, col, method, params) {
   // (new Date('2015-10-28')).toDateString() may return 2015-10-27 because the
   // actual time created could be like 'Tue Oct 27 2015 19:00:00 GMT-0500 (CDT)',
   // i.e. the date-only string is treated as UTC time instead of local time
-  if (method === 'toDateString' && /^\d{4,}\D\d{2}\D\d{2}$/.test(d)) {
+  if ((method === 'toDateString' || method === 'toLocaleDateString') && /^\d{4,}\D\d{2}\D\d{2}$/.test(d)) {
     d = d.split(/\D/);
     d = new Date(d[0], d[1] - 1, d[2]);
   } else {


### PR DESCRIPTION
Closes #538 

# DESCRIPTION

Fix the bug that `formatDate()` may display dates off by one day when method = "toLocaleDateString".

This PR is a patch for https://github.com/rstudio/DT/commit/3d8fa2479219d981c5a06f4dd31be358cc21a9aa ( The fix to https://github.com/rstudio/DT/issues/198)

# Example 

However, it requires the timezone of you browser being set to UTC minus XXX like EST to reproduce.

```r
DT::datatable(data.frame(x="2018-01-01")) %>% formatDate('x', method="toLocaleDateString")
DT::datatable(data.frame(x=as.Date("2018-01-01"))) %>% formatDate('x', method="toLocaleDateString")
```