### PR TITLE
`coerceValue()` no longer throws warnings for class `charactor`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.10
+Version: 0.4.11
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 - Fix the bug that `formatDate()` may display dates off by one day when method = "toLocaleDateString" (thanks, @shrektan @DevMui, #539 #538).
 
+- `coerceValue()` no longer throws warnings for class `charactor` (thanks, @shrektan, #541 #542).
+
 ## NEW FEATURES
 
 - The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content if `formatDate()` is applied on these columns (thanks, @shrektan, #522 #241).

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,6 +72,7 @@ classes = function(x) paste(class(x), collapse = ', ')
 coerceValue = function(val, old) {
   if (is.integer(old)) return(as.integer(val))
   if (is.numeric(old)) return(as.numeric(val))
+  if (is.character(old)) return(as.character(val))
   if (inherits(old, 'Date')) return(as.Date(val))
   if (inherits(old, c('POSIXlt', 'POSIXct'))) {
     val = strptime(val, '%Y-%m-%dT%H:%M:%SZ', tz = 'UTC')


### PR DESCRIPTION
Closes #541 

`DT:::coerceValue()` should now throws warning for characters.

```r
DT:::coerceValue("a", "b")
#> Warning in DT:::coerceValue("a", "b"): The data type is not supported:
#> character
#> [1] "a"
packageVersion("DT")
#> [1] '0.4.10'
```