### PR TITLE
Support for Shiny async

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,8 +30,6 @@ Imports:
     magrittr,
     crosstalk,
     promises
-Remotes:
-    rstudio/promises
 Suggests:
     jsonlite (>= 0.9.16),
     knitr (>= 1.8),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,10 @@ Imports:
     htmltools (>= 0.3.6),
     htmlwidgets (>= 1.0),
     magrittr,
-    crosstalk
+    crosstalk,
+    promises
+Remotes:
+    rstudio/promises
 Suggests:
     jsonlite (>= 0.9.16),
     knitr (>= 1.8),


### PR DESCRIPTION
Normally, htmlwidgets don't require any work to be compatible with Shiny async. But DT is different because it has these `currentSession`/`currentOutputName` variables that rely on all of the rendering code being executed synchronously (as these variables are maintained using the call stack). Maintaining these kinds of "contextual" global variables is harder with async but still possible, as this is what [promise domains](https://gist.github.com/jcheng5/b1c87bb416f6153643cd0470ac756231) were invented for.

Example app:

```r
library(shiny)
library(DT)
library(promises)
library(future)
plan(multiprocess)


tblOutputUI <- function(id) {
  ns <- NS(id)
  DT::dataTableOutput(ns("table"))
}

tblOutput <- function(input, output, session, df) {
  output$table <- DT::renderDataTable({
    future({ Sys.sleep(0.1); df }) %...>%
      identity()
  })
}


ui <- fluidPage(
  numericInput("nrow", "Number of rows", 50),
  DT::dataTableOutput("table"),
  tblOutputUI("one")
)

server <- function(input, output, session) {
  output$table <- DT::renderDataTable({
    future({ Sys.sleep(0.1); cars }) %...>%
      head(input$nrow)
  })
  
  callModule(tblOutput, "one", mtcars)
}

shinyApp(ui, server)
```