### PR TITLE
fix the scroll bar issue in IE11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.10
+Version: 0.4.11
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 - Fix the bug that `formatDate()` may display dates off by one day when method = "toLocaleDateString" (thanks, @shrektan @DevMui, #539 #538).
 
+- Fix the bug that in IE11, the scroll bar of the filter will disappear when you try to click it (thanks, @shrektan, #557 #556).
+
 ## NEW FEATURES
 
 - The filters of `Date` or `Datetime` columns now display the same format and timezone as the column content if `formatDate()` is applied on these columns (thanks, @shrektan, #522 #241).

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -440,9 +440,7 @@ HTMLWidgets.widget({
             }
           });
           if (searchCol) filter[0].selectize.setValue(JSON.parse(searchCol));
-          // an ugly hack to deal with shiny: for some reason, the onBlur event
-          // of selectize does not work in shiny
-          $x.find('div > div.selectize-input > input').on('blur', function() {
+          filter[0].selectize.on('blur', function() {
             $x.hide().trigger('hide'); $input.parent().show(); $input.trigger('blur');
           });
           filter.next('div').css('margin-bottom', 'auto');


### PR DESCRIPTION
closes #556 

## DESCRIPTION

In IE11, the scroll bar of the selectize input of the filter will disappear when you try to click it. This PR will fix this issue. 

The comment of the changed line says:

> an ugly hack to deal with shiny: for some reason, the onBlur event of selectize does not work in shiny

My example shows it works in shiny as well. Hopefully, I don't miss anything.

## Example1

```r
library(DT)
df <- data.frame(a = LETTERS)
datatable(df, filter = 'top')
```

## Example2

```r
library(shiny)
library(DT)
df <- data.frame(a = LETTERS)
ui <- basicPage(DT::DTOutput("dt"))
server <- function(input, output) {
  output$dt <- DT::renderDT(df, filter = "top")
}
runApp(list(ui = ui, server = server))
```