### PR TITLE
add the param default for `styleEqual()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.12
+Version: 0.4.14
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - You can now show and hide columns from shiny using `showCols()` and `hideCols()`, and reorder the the display of columns using `colReorder()` (thanks, @gergness, #527).
 
+- You can now set the default CSS value in `styleEqual()` by using the newe param `default` (thanks, @shrektan, #558, #546).
+
 ## BUG FIXES
 
 - `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495).

--- a/R/format.R
+++ b/R/format.R
@@ -302,12 +302,15 @@ styleInterval = function(cuts, values) {
 
 #' @param levels a character vector of data values to be mapped (one-to-one) to
 #'   CSS values
+#' @param default a string used as the the default CSS value for values other than levels
 #' @export
 #' @rdname styleInterval
-styleEqual = function(levels, values) {
+styleEqual = function(levels, values, default = "") {
   n = length(levels)
   if (n != length(values))
     stop("length(levels) must be equal to length(values)")
+  if (!is.character(default) || length(default) != 1)
+    stop("default must be a string")
   if (n == 0) return("''")
   levels2 = levels
   if (is.character(levels)) levels2 = gsub("'", "\\'", levels)
@@ -317,7 +320,7 @@ styleEqual = function(levels, values) {
   for (i in seq_len(n)) {
     js = paste0(js, sprintf("value == %s ? '%s' : ", levels2[i], values[i]))
   }
-  JS(paste0(js, "''"))
+  JS(paste0(js, sprintf("'%s'", default)))
 }
 
 #' @param data a numeric vector whose range will be used for scaling the

--- a/man/styleInterval.Rd
+++ b/man/styleInterval.Rd
@@ -8,7 +8,7 @@
 \usage{
 styleInterval(cuts, values)
 
-styleEqual(levels, values)
+styleEqual(levels, values, default = "")
 
 styleColorBar(data, color, angle = 90)
 }
@@ -19,6 +19,8 @@ styleColorBar(data, color, angle = 90)
 
 \item{levels}{a character vector of data values to be mapped (one-to-one) to
 CSS values}
+
+\item{default}{a string used as the the default CSS value for values other than levels}
 
 \item{data}{a numeric vector whose range will be used for scaling the
 table data from 0-100 before being represented as color bars. A vector


### PR DESCRIPTION
Closes #546

### DESCRIPTION

Before this PR, you can't set the default css value for a column, even if you try to do it like below (I don't why...).

``` r
library(DT)
df <- data.frame(a = 0:9)
tmp <- datatable(df) %>%
  DT::formatStyle("a", backgroundColor = styleEqual(0, "green")) %>%
  DT::formatStyle("a", backgroundColor = "red")
cat(tmp$x$options$rowCallback)
#> function(row, data) {
#> var value=data[1]; $(this.api().cell(row, 1).node()).css({'background-color':'red'});
#> var value=data[1]; $(this.api().cell(row, 1).node()).css({'background-color':value == 0.000000 ? 'green' : ''});
#> }
tmp
```

Anyway, it makes sense to me to be able to set the default CSS value.

### Example 

```r
library(DT)
df <- data.frame(a = 0:9)
datatable(df) %>%
  DT::formatStyle("a", backgroundColor = styleEqual(0, "green", default = "red"))
datatable(df) %>%
  DT::formatStyle("a", backgroundColor = styleEqual(0, "green"))
```