### PR TITLE
Improve format*() functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.4.15
+Version: 0.4.16
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - You can now set the default CSS value in `styleEqual()` by using the newe param `default` (thanks, @shrektan, #558, #546).
 
+- The js callbacks generated from the `format*()` functions will be executed in sequential order. `formatString()` will change the cells based on the existing content rather than the raw data (thanks, @shrektan, #576).
+
 ## BUG FIXES
 
 - `styleInterval()` and `styleEqual()` now generates the correct callback for `Date` and `Datetime` values. (thanks, @shrektan, #500, #495).

--- a/R/format.R
+++ b/R/format.R
@@ -173,7 +173,7 @@ appendFormatter = function(js, name, names, rownames = TRUE, template, ...) {
   }
   i = name2int(name, names, rownames)
   JS(append(
-    js, after = 1,
+    js, after = length(js) - 1,
     template(i, ..., names, rownames)
   ))
 }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -29,7 +29,8 @@ DTWidget.formatCurrency = function(thiz, row, data, col, currency, digits, inter
 DTWidget.formatString = function(thiz, row, data, col, prefix, suffix) {
   var d = data[col];
   if (d === null) return;
-  $(thiz.api().cell(row, col).node()).html(prefix + d + suffix);
+  var content = $(thiz.api().cell(row, col).node()).html();
+  $(thiz.api().cell(row, col).node()).html(prefix + content + suffix);
 };
 
 DTWidget.formatPercentage = function(thiz, row, data, col, digits, interval, mark, decMark) {


### PR DESCRIPTION
Closes #560 

As mentioned in the comment of #560 , 

- The `format*()` functions should be executed in the same order as it's defined in R.
- `formatString()` should allowed to be added after `formatSignif()` or similar.

### EXAMPLE

```r
library(DT)
dt <- 
  DT::datatable(iris) %>%
  formatPercentage("Sepal.Length", digits = 5) %>%
  formatString("Sepal.Length", suffix = "units")
cat(dt$x$options$rowCallback)
dt
```

### BEFORE THE PR

```r
#> function(row, data) {
#> DTWidget.formatString(this, row, data, 1, '', 'units');
#> DTWidget.formatPercentage(this, row, data, 1, 5, 3, ',', '.');
#> }
```

<img width="679" alt="2018-07-27 12 27 49" src="https://user-images.githubusercontent.com/8368933/43275444-65722e54-9134-11e8-8829-d0bd62bbf606.png">


### AFTER THE PR

```r
#> function(row, data) {
#> DTWidget.formatPercentage(this, row, data, 1, 5, 3, ',', '.');
#> DTWidget.formatString(this, row, data, 1, '', 'units');
#> }
```
<img width="683" alt="image" src="https://user-images.githubusercontent.com/8368933/43275518-9170f35a-9134-11e8-813b-30f3245c90d7.png">
