### PR TITLE
Replace the rawgit.com URLs with raw.githubusercontent.com

### DIFF
--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -66,8 +66,8 @@ invisible(lapply(list.files(), function(ext) {
     unlink(file.path(ext, 'css', '*.scss'))
     for (u in c(
       'https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js',
-      'https://cdn.rawgit.com/bpampuch/pdfmake/0.1.18/build/pdfmake.min.js',
-      'https://cdn.rawgit.com/bpampuch/pdfmake/0.1.18/build/vfs_fonts.js'
+      'https://raw.githubusercontent.com/bpampuch/pdfmake/0.1.18/build/pdfmake.min.js',
+      'https://raw.githubusercontent.com/bpampuch/pdfmake/0.1.18/build/vfs_fonts.js'
     )) download.file(u, file.path(ext, 'js', basename(u)))
   }
   allf = list.files(ext, all.files = TRUE, recursive = TRUE, full.names = TRUE, no.. = TRUE)


### PR DESCRIPTION
Closes #607 

It's strange that I can't use `download.file()` to fetch cdn.rawgit.com files, despite that I'm using a VPN... (I can use Safari to browser cdn.rawgit.com, though).

So I execute the update_DT.R and find no change in git, so it should be ok.

In addition, I notice some minor issues in update_DT.R:

- The RowReorder extension files will still be empty;
- Some directories need to be created in advance, otherwise it throws errors.

