### PR TITLE
DT-626 - fixed issue with non-working reloadData/replaceData 

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -443,7 +443,7 @@ dataTableAjax = function(session, data, rownames, filter = dataTablesFilter, out
   data = as.data.frame(data)  # think dplyr
   if (length(rn)) data = cbind(' ' = rn, data)
 
-  sessionDataURL(session, data, outputId, filter)
+  sessionDataURL(session, data, session$ns(outputId), filter)
 }
 
 sessionDataURL = function(session, data, id, filter) {


### PR DESCRIPTION
DT-626 - fixed issue with non-working reloadData/replaceData  method when called within Shiny Modules.

This bug was introduced in 820361cb1d917118b0b2551a5a9c69cb77e0a12b, where support for pomises was added.
The problem onlly occured when DT was used inside a shiny module. The reloadData used non-namespaced outputId
identifier and from this reason the initial callback URL differed from the URL on which the reloadData
binded.

This fixes #626 