### PR TITLE
Rename filterFunc to funcFilter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- Added a `filterFunc` argument to `DT::renderDT()` (thanks, @galachad, #638).
+- Added a `funcFilter` argument to `DT::renderDT()` (thanks, @galachad, #638).
 
 ## BUG FIXES
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -47,14 +47,14 @@ DTOutput = dataTableOutput
 #'   \code{FALSE}, then the entire data frame is sent to the browser at once.
 #'   Highly recommended for medium to large data frames, which can cause
 #'   browsers to slow down or crash.
-#' @param filterFunc (for expert use only) passed to the \code{filter} argument
+#' @param funcFilter (for expert use only) passed to the \code{filter} argument
 #'   of \code{\link{dataTableAjax}()}
 #' @param ... ignored when \code{expr} returns a table widget, and passed as
 #'   additional arguments to \code{datatable()} when \code{expr} returns a data
 #'   object
 renderDataTable = function(
     expr, server = TRUE, env = parent.frame(), quoted = FALSE,
-    filterFunc = dataTablesFilter, ...
+    funcFilter = dataTablesFilter, ...
   ) {
   if (!quoted) expr = substitute(expr)
 
@@ -112,7 +112,7 @@ renderDataTable = function(
       }
 
       if (is.null(options[['ajax']][['url']])) {
-        url = sessionDataURL(outputInfoEnv[["session"]], origData, outputInfoEnv[["outputName"]], filterFunc)
+        url = sessionDataURL(outputInfoEnv[["session"]], origData, outputInfoEnv[["outputName"]], funcFilter)
         options$ajax$url = url
       }
       instance$x$options = fixServerOptions(options)

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -12,10 +12,10 @@ dataTableOutput(outputId, width = "100\%", height = "auto")
 DTOutput(outputId, width = "100\%", height = "auto")
 
 renderDataTable(expr, server = TRUE, env = parent.frame(), quoted = FALSE, 
-    filterFunc = dataTablesFilter, ...)
+    funcFilter = dataTablesFilter, ...)
 
 renderDT(expr, server = TRUE, env = parent.frame(), quoted = FALSE, 
-    filterFunc = dataTablesFilter, ...)
+    funcFilter = dataTablesFilter, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the table from}
@@ -39,7 +39,7 @@ browsers to slow down or crash.}
 \item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
 
-\item{filterFunc}{(for expert use only) passed to the \code{filter} argument
+\item{funcFilter}{(for expert use only) passed to the \code{filter} argument
 of \code{\link{dataTableAjax}()}}
 
 \item{...}{ignored when \code{expr} returns a table widget, and passed as


### PR DESCRIPTION
Closes #639 

#638 added a new param `filterFunc` to `renderDT()`. When users call it with the argument `filter`, it's `filterFunc` that being matched, thanks to R's partial matching... So, `filter` will never be passed to `...` and thus to `datatable()` unless `filterFunc` being provided at the same time.

There're two ways to fix this:

- Rename the `filterFunc` like `funcFilter`,
- [Add the `filter` param explicitly](https://github.com/rstudio/DT/compare/master...shrektan:fix639).

The first solution looks simpler and cleaner to me. 

```f
library(shiny)
library(DT)

ui <- fluidPage(DTOutput("dat"))

server <- function(input, output, session) {
  output$dat <- renderDT(mtcars[FALSE, ], filter = 'top')
}

shinyApp(ui, server)
```