### PR TITLE
`cell_edit` now always triggers a reactive event on the R side

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests:
     jsonlite (>= 0.9.16),
     knitr (>= 1.8),
     rmarkdown,
-    shiny (>= 0.12.1)
+    shiny (>= 1.1.0)
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - Fix issue where `replaceData()` didn't work when used in Shiny modules. (Thanks, @donarus, #628, #626)
 
+- The javascript event `cell_edit` now always triggers a reactive event on the R side. Since `cell_edit` will only be triggered when the value shown on the table has been changed so it's almost always what user expects (thanks, @shrektan @stelmath, #647 #645).
+
 # CHANGES IN DT VERSION 0.5
 
 ## NEW FEATURES

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -721,7 +721,7 @@ HTMLWidgets.widget({
         var valueNew = $input.val();
         if (valueNew != value) {
           table.cell($this).data(valueNew);
-          if (HTMLWidgets.shinyMode) changeInput('cell_edit', cellInfo($this));
+          if (HTMLWidgets.shinyMode) changeInput('cell_edit', cellInfo($this), null, null, {priority: "event"});
           // for server-side processing, users have to call replaceData() to update the table
           if (!server) table.draw(false);
         } else {
@@ -747,18 +747,18 @@ HTMLWidgets.widget({
     // register clear functions to remove input values when the table is removed
     instance.clearInputs = {};
 
-    var changeInput = function(id, value, type, noCrosstalk) {
+    var changeInput = function(id, value, type, noCrosstalk, opts) {
       var event = id;
       id = el.id + '_' + id;
       if (type) id = id + ':' + type;
       // do not update if the new value is the same as old value
-      if (shinyData.hasOwnProperty(id) && shinyData[id] === JSON.stringify(value))
+      if (event !== 'cell_edit' && shinyData.hasOwnProperty(id) && shinyData[id] === JSON.stringify(value))
         return;
       shinyData[id] = JSON.stringify(value);
       if (HTMLWidgets.shinyMode) {
-        Shiny.onInputChange(id, value);
+        Shiny.setInputValue(id, value, opts);
         if (!instance.clearInputs[id]) instance.clearInputs[id] = function() {
-          Shiny.onInputChange(id, null);
+          Shiny.setInputValue(id, null);
         }
       }
 


### PR DESCRIPTION
Closes #645

Since `cell_edit` will only be triggered when the value shown on the table has been changed so it's almost always what user expects.

### Steps to Reproduce

1. Run the app
1. Edit any cell to any value, e.g., cell(1,1) to "aaa" 
1. Click the button
1. Edit again with the same value "aaa"

Previously the reactive events won't be triggered. With this PR, it will.


### Code

```r
library(shiny)
library(DT)
shinyApp(
  ui = fluidPage(
    fluidRow(
      verbatimTextOutput('edit_content'),
      column(2, actionButton('refresh', 'Refresh Data', icon = icon('refresh'))),
      column(10, DT::dataTableOutput('foo'))
    )
  ),
  server = function(input, output, session) {
    loopData = reactive({
      input$refresh
      iris
    })
    output$foo = DT::renderDataTable(isolate(loopData()), editable = TRUE)
    proxy = dataTableProxy('foo')
    observe({
      replaceData(proxy, loopData(), resetPaging = FALSE)
    })
    observeEvent(input$foo_cell_edit, {
      print("an edit occured")
    })
    output$edit_content <- renderPrint({
      print(paste(Sys.time(), "trigger"))
      str(input$foo_cell_edit)
    })
  }
)
```