### PR TITLE
Added option to editable parameter for column selection

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -209,6 +209,7 @@ datatable = function(
 
   if (isTRUE(editable)) editable = 'cell'
   if (is.character(editable)) params$editable = editable
+  if (is.numeric(editable)) params$editable = jsonlite::toJSON(editable)
 
   if (!identical(class(callback), class(JS(''))))
     stop("The 'callback' argument only accept a value returned from JS()")

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -710,7 +710,16 @@ HTMLWidgets.widget({
     if (typeof data.callback === 'function') data.callback(table);
 
     // double click to edit the cell, row, column, or all cells
-    if (data.editable) table.on('dblclick.dt', 'tbody td', function(e) {
+    var editableSelector = 'tbody td';
+    if(Array.isArray(data.editable)) {
+      editableSelector = 'tbody td:nth-child(' + data.editable[0] + ')';
+      for (var i = 1; i < data.editable.length; i++) {
+        editableSelector += ', tbody td:nth-child(' + data.editable[i] + ')';
+      }
+      data.editable = 'cell';
+    }
+
+    if (data.editable) table.on('dblclick.dt', editableSelector, function(e) {
       // only bring up the editor when the cell itself is dbclicked, and ignore
       // other dbclick events bubbled up (e.g. from the <input>)
       if (e.target !== this) return;

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -4,13 +4,14 @@
 \alias{datatable}
 \title{Create an HTML table widget using the DataTables library}
 \usage{
-datatable(data, options = list(), class = "display", callback = JS("return table;"), 
-    rownames, colnames, container, caption = NULL, filter = c("none", 
-        "bottom", "top"), escape = TRUE, style = "default", width = NULL, 
-    height = NULL, elementId = NULL, fillContainer = getOption("DT.fillContainer", 
-        NULL), autoHideNavigation = getOption("DT.autoHideNavigation", 
-        NULL), selection = c("multiple", "single", "none"), extensions = list(), 
-    plugins = NULL, editable = FALSE)
+datatable(data, options = list(), class = "display",
+  callback = JS("return table;"), rownames, colnames, container,
+  caption = NULL, filter = c("none", "bottom", "top"), escape = TRUE,
+  style = "default", width = NULL, height = NULL, elementId = NULL,
+  fillContainer = getOption("DT.fillContainer", NULL),
+  autoHideNavigation = getOption("DT.autoHideNavigation", NULL),
+  selection = c("multiple", "single", "none"), extensions = list(),
+  plugins = NULL, editable = FALSE)
 }
 \arguments{
 \item{data}{a data object (either a matrix or a data frame)}
@@ -99,7 +100,9 @@ plugins supported by the \code{DT} package can be used here.}
 \item{editable}{\code{FALSE} to disable the table editor, or \code{TRUE} (or
 \code{"cell"}) to enable editing a single cell. Alternatively, you can set
 it to \code{"row"} to be able to edit a row, or \code{"column"} to edit a
-column, or \code{"all"} to edit all cells on the current page of the table.
+column, or \code{"all"} to edit all cells on the current page of the table. 
+Additionally, you can specify a vector e.g. \code{"c(1,2)"} of column numbers 
+that should be editable.
 In all modes, start editing by doubleclicking on a cell.}
 }
 \description{


### PR DESCRIPTION
We implemented a small change that should close #550. Our solution extends the `editable` parameter of the `datatable` function to accept vectors specifying the editable columns.

In case there are any documentation things we missed (this is my first pull request on github ;-) ), please let me know and I will extend the pull request.

Cheers,
Sebastian