### PR TITLE
Escape mark and dec.mark for various formatters

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -57,6 +57,7 @@ formatCurrency = function(
 ) {
   currency = gsub("'", "\\\\'", currency)
   mark = gsub("'", "\\\\'", mark)
+  dec.mark = gsub("'", "\\\\'", dec.mark)
   formatColumns(table, columns, tplCurrency, currency, interval, mark, digits, dec.mark, before)
 }
 
@@ -74,6 +75,8 @@ formatString = function(table, columns, prefix = '', suffix = '') {
 formatPercentage = function(
   table, columns, digits = 0, interval = 3, mark = ',', dec.mark = getOption('OutDec')
 ) {
+  mark = gsub("'", "\\\\'", mark)
+  dec.mark = gsub("'", "\\\\'", dec.mark)
   formatColumns(table, columns, tplPercentage, digits, interval, mark, dec.mark)
 }
 
@@ -82,6 +85,8 @@ formatPercentage = function(
 formatRound = function(
   table, columns, digits = 2, interval = 3, mark = ',', dec.mark = getOption('OutDec')
 ) {
+  mark = gsub("'", "\\\\'", mark)
+  dec.mark = gsub("'", "\\\\'", dec.mark)
   formatColumns(table, columns, tplRound, digits, interval, mark, dec.mark)
 }
 
@@ -90,6 +95,8 @@ formatRound = function(
 formatSignif = function(
   table, columns, digits = 2, interval = 3, mark = ',', dec.mark = getOption('OutDec')
 ) {
+  mark = gsub("'", "\\\\'", mark)
+  dec.mark = gsub("'", "\\\\'", dec.mark)
   formatColumns(table, columns, tplSignif, digits, interval, mark, dec.mark)
 }
 


### PR DESCRIPTION
Closes #666 and is slightly more general in that it also fixes the problem not only for formatRound and also not only for the argument `mark`. The PR adds escaping for the arguments `mark` and `dec.mark` for the following formatters:

- `formatCurrency`
- `formatPercentage`
- `formatRound`
- `formatSignif`