### PR TITLE
better jsValues() to convert R object to js values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,11 +28,11 @@ License: GPL-3 | file LICENSE
 Imports:
     htmltools (>= 0.3.6),
     htmlwidgets (>= 1.3),
+    jsonlite (>= 0.9.16),
     magrittr,
     crosstalk,
     promises
 Suggests:
-    jsonlite (>= 0.9.16),
     knitr (>= 1.8),
     rmarkdown,
     shiny (>= 1.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.7.1
+Version: 0.7.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - For `datatable()`, `options$buttons` now works as expected when providing a scalar string or a boolean value (thanks, @shrektan, #685 #658).
 
-- Fix the issue that when params contain the single quote character, it may result in incorrect javascript codes due to failing to escape the single quote (thanks, @shrektan #683 #666).
+- Fix the issue that when parameters of the `formatXXX()` functions contain single quotes, they may lead to incorrect JavasSript code due to failing to escape the single quotes (thanks, @shrektan #683 #666, @lorenzwalthert #667).
 
 # CHANGES IN DT VERSION 0.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - For `datatable()`, `options$buttons` now works as expected when providing a scalar string or a boolean value (thanks, @shrektan, #685 #658).
 
+- Fix the issue that when params contain the single quote character, it may result in incorrect javascript codes due to failing to escape the single quote (thanks, @shrektan #683 #666).
+
 # CHANGES IN DT VERSION 0.7
 
 ## BUG FIXES
@@ -27,8 +29,6 @@
 - The JavaScript event `cell_edit` now always triggers a reactive event on the R side. Since `cell_edit` will only be triggered when the value shown on the table has been changed so it's almost always what user expects (thanks, @shrektan @stelmath, #647 #645).
 
 - Fix the issue that the server-side search option doesn't handle exotic encoding correctly, because after httpuv v1.5.0, `shiny::parseQueryString()` always assumes the input is an UTF-8 encoded string (thanks, @shrektan @phileas-condemine, #656).
-
-- Fix the issue that when params contain the single quote character, it may result in incorrect javascript codes due to failing to escape the single quote (thanks, @shrektan #683 #666).
 
 # CHANGES IN DT VERSION 0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 - Fix the issue that the server-side search option doesn't handle exotic encoding correctly, because after httpuv v1.5.0, `shiny::parseQueryString()` always assumes the input is an UTF-8 encoded string (thanks, @shrektan @phileas-condemine, #656).
 
+- Fix the issue that when params contain the single quote character, it may result in incorrect javascript codes due to failing to escape the single quote (thanks, @shrektan #683 #666).
+
 # CHANGES IN DT VERSION 0.5
 
 ## NEW FEATURES

--- a/R/format.R
+++ b/R/format.R
@@ -256,9 +256,7 @@ jsValues = function(x) {
   } else if (inherits(x, "Date")) {
     x = format(x, "%Y-%m-%d")
   }
-  sapply(x, function(v) {
-    jsonlite::toJSON(jsonlite::unbox(v))
-  }, simplify = TRUE, USE.NAMES = FALSE)
+  vapply(x, jsonlite::toJSON, character(1), auto_unbox = TRUE)
 }
 
 

--- a/R/format.R
+++ b/R/format.R
@@ -182,7 +182,7 @@ tplCurrency = function(cols, currency, interval, mark, digits, dec.mark, before,
   sprintf(
     "DTWidget.formatCurrency(this, row, data, %d, %s, %d, %d, %s, %s, %s);",
     cols, jsValues(currency), digits, interval, jsValues(mark), jsValues(dec.mark),
-    jsValues(isTRUE(before))
+    jsValues(before)
   )
 }
 

--- a/R/format.R
+++ b/R/format.R
@@ -320,7 +320,7 @@ styleEqual = function(levels, values, default = "") {
   for (i in seq_len(n)) {
     js = paste0(js, sprintf("value == %s ? %s : ", levels[i], values[i]))
   }
-  JS(paste0(js, sprintf("%s", jsValues(default))))
+  JS(paste0(js, jsValues(default)))
 }
 
 #' @param data a numeric vector whose range will be used for scaling the


### PR DESCRIPTION
Closes #666  also use %d when expecting integer. 

PS: Didn't notice #667 but I believe this way is more robust by taking advantage of jsonlite.

# The tests for `jsValues()`

``` r
cat(DT:::jsValues(Sys.Date()))
#> "2019-07-11"
cat(DT:::jsValues(Sys.time()))
#> "2019-07-11T15:27:40Z"
cat(DT:::jsValues(1L:3L))
#> 1 2 3
cat(DT:::jsValues(c(1.0, 2.3)))
#> 1 2.3
cat(DT:::jsValues(letters[1:5]))
#> "a" "b" "c" "d" "e"
```

<sup>Created on 2019-07-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

# Examples

```r
library(magrittr)
library(DT)

# https://github.com/rstudio/DT/issues/666
# This doesn't work before the change
DT::datatable(data.frame(x = 1e5)) %>%
  DT::formatRound("x", mark = "'")

# https://github.com/rstudio/DT/pull/516
# still working
options(OutDec=',')
datatable(iris) %>% 
  formatStyle(1,color=styleInterval(c(4.9),c('green','red'))) %>%
  formatStyle(2,color=styleEqual(c(3.1, 3.2),c('green','red'))) %>%
  formatStyle(
    'Petal.Length',
    background = styleColorBar(iris$Petal.Length, 'grey'),
    backgroundSize = '100% 90%',
    backgroundRepeat = 'no-repeat',
    backgroundPosition = 'center'
  )

# https://github.com/rstudio/DT/pull/500
# still working

library(DT)
dates <- as.Date(c("2018-01-01","2019-01-01"))
times <- as.POSIXct(c("2018-01-01 15:00", "2018-01-01 20:00"), tz = "UTC")
tbl <- 
  data.frame(
    Date = dates,
    Date2 = dates,
    Time = times,
    Time2 = times,
    Time3 = times,
    Time4 = times
  )
tbl %>%
  datatable() %>%
  formatStyle(columns = c("Date", "Date2"),
              backgroundColor = styleInterval(as.Date("2018-02-02"), c("#FB717E", "#89EC6A"))) %>%
  formatStyle(columns = c("Time", "Time2"),
              backgroundColor = styleInterval(as.POSIXct(c("2018-01-01 18:00"), tz = "UTC"), c("#FB717E", "#89EC6A"))) %>%
  formatStyle(columns = c("Time3"),
              backgroundColor = styleInterval(as.POSIXct(c("2018-01-02 02:00"), tz = "PRC"), c("#FB717E", "#89EC6A"))) %>%
  formatStyle(columns = c("Time4"),
              backgroundColor = styleEqual(times, c("#FB717E", "#89EC6A"))) %>%
  formatDate(columns = c("Date2", "Time2"), c("toDateString", "toTimeString"))
```