### PR TITLE
Better doc on column indices provided in escape when using rownames

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -43,7 +43,9 @@
 #'   alternatively, you can specify numeric column indices or column names to
 #'   indicate which columns to escape, e.g. \code{1:5} (the first 5 columns),
 #'   \code{c(1, 3, 4)}, or \code{c(-1, -3)} (all columns except the first and
-#'   third), or \code{c('Species', 'Sepal.Length')}
+#'   third), or \code{c('Species', 'Sepal.Length')}; since the row names take
+#'   the first column to display, you should add the numeric column indices
+#'   by one when using \code{rownames}
 #' @param style the style name (\url{http://datatables.net/manual/styling/});
 #'   currently only \code{'default'} and \code{'bootstrap'} are supported
 #' @param width,height Width/Height in pixels (optional, defaults to automatic

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -63,7 +63,9 @@ to escape the whole table, and \code{FALSE} means not to escape it;
 alternatively, you can specify numeric column indices or column names to
 indicate which columns to escape, e.g. \code{1:5} (the first 5 columns),
 \code{c(1, 3, 4)}, or \code{c(-1, -3)} (all columns except the first and
-third), or \code{c('Species', 'Sepal.Length')}}
+third), or \code{c('Species', 'Sepal.Length')}; since the row names take
+the first column to display, you should add the numeric column indices
+by one when using \code{rownames}}
 
 \item{style}{the style name (\url{http://datatables.net/manual/styling/});
 currently only \code{'default'} and \code{'bootstrap'} are supported}


### PR DESCRIPTION
As requested in #691.