### PR TITLE
Fix #669

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Fix the issue that when parameters of the `formatXXX()` functions contain single quotes, they may lead to incorrect JavasSript code due to failing to escape the single quotes (thanks, @shrektan #683 #666, @lorenzwalthert #667).
 
+- Fix the issue that the first column can't be disabled from editing (thanks, @tsolloway, @haozhu233, #669, #694)
+
 # CHANGES IN DT VERSION 0.7
 
 ## BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 - Fix the issue that when parameters of the `formatXXX()` functions contain single quotes, they may lead to incorrect JavasSript code due to failing to escape the single quotes (thanks, @shrektan #683 #666, @lorenzwalthert #667).
 
-- Fix the issue that the first column can't be disabled from editing (thanks, @tsolloway, @haozhu233, #669, #694)
+- Fix the issue that the first column can't be disabled from editing (thanks, @tsolloway #669, @haozhu233 #694).
 
 # CHANGES IN DT VERSION 0.7
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -743,7 +743,7 @@ HTMLWidgets.widget({
             $input.attr('title', 'Hit Ctrl+Enter to finish editing, or Esc to cancel');
           }
           $input.val(value);
-          if (disableCols && inArray(_cell.index().column, disableCols)) {
+          if ((disableCols === 0 || disableCols) && inArray(_cell.index().column, disableCols)) {
             $input.attr('readonly', '').css('filter', 'invert(25%)');
           }
           $cell.empty().append($input);

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -743,7 +743,7 @@ HTMLWidgets.widget({
             $input.attr('title', 'Hit Ctrl+Enter to finish editing, or Esc to cancel');
           }
           $input.val(value);
-          if ((disableCols === 0 || disableCols) && inArray(_cell.index().column, disableCols)) {
+          if (inArray(_cell.index().column, disableCols)) {
             $input.attr('readonly', '').css('filter', 'invert(25%)');
           }
           $cell.empty().append($input);


### PR DESCRIPTION
As reported in #669, if user wants to disable editing for the first column,

```
DT::datatable(
    head(iris),
    rownames = FALSE,
    editable = list(target = "column", disable=list(columns=0))
)
```

they can't because in this line of code
https://github.com/rstudio/DT/blob/e8fe21fb0839fcf3fb476def1329239137d6672c/inst/htmlwidgets/datatables.js#L746

if `disableCols` just equals to 0, it will be treated as false.  