### PR TITLE
Filter boxes display in correct position when there're many columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## BUG FIXES
 
 - Fix the issue that the first column can't be disabled from editing (thanks, @tsolloway #669, @haozhu233 #694).
+- Fix the issue that the filter boxes are not anchored to the corresponding value columns when there are many columns (thanks, @philibe, #554).
 
 # CHANGES IN DT VERSION 0.8
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -404,11 +404,27 @@ HTMLWidgets.widget({
 
         // remove the overflow: hidden attribute of the scrollHead
         // (otherwise the scrolling table body obscures the filters)
+        // The workaround and the discussion from
+        // https://github.com/rstudio/DT/issues/554#issuecomment-518007347
+        // Otherwise the filter selection will not be anchored to the values
+        // when the columns number is many and scrollX is enabled.
         var scrollHead = $(el).find('.dataTables_scrollHead,.dataTables_scrollFoot');
-        var cssOverflow = scrollHead.css('overflow');
-        if (cssOverflow === 'hidden') {
+        var cssOverflowHead = scrollHead.css('overflow');
+        var scrollBody = $(el).find('.dataTables_scrollBody');
+        var cssOverflowBody = scrollBody.css('overflow');
+        var scrollTable = $(el).find('.dataTables_scroll');
+        var cssOverflowTable = scrollTable.css('overflow');
+        if (cssOverflowHead === 'hidden') {
           $x.on('show hide', function(e) {
-            scrollHead.css('overflow', e.type === 'show' ? '' : cssOverflow);
+            if (e.type === 'show') {
+              scrollHead.css('overflow', 'visible');
+              scrollBody.css('overflow', 'visible');
+              scrollTable.css('overflow-x', 'scroll');
+            } else {
+              scrollHead.css('overflow', cssOverflowHead);
+              scrollBody.css('overflow', cssOverflowBody);
+              scrollTable.css('overflow-x', cssOverflowTable);
+            }
           });
           $x.css('z-index', 25);
         }


### PR DESCRIPTION
Closes #554 

Not an elegant solution but maybe the only way that works. It looks harmless to me because the css attributes will be reverted back later.

Thanks @philibe for providing the css code.

### Example code

```r
library(DT)
df <- do.call(data.frame, c(setNames(lapply(LETTERS, function(x) iris$Species), letters), list(stringsAsFactors = FALSE)))
datatable(df, filter = 'top', options = list(scrollX = "30%"))
```

### Before

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/8368933/63023347-862f3e80-bed7-11e9-87f0-655ec79b4cca.png">

### After

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/8368933/63023407-a65efd80-bed7-11e9-882f-2931a05bb757.png">