### PR TITLE
`formatStyle()` with `styleEqual()` is now chainable by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.8.3
+Version: 0.8.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN DT VERSION 0.9
 
+## NEW FEATURES
+
+- `formatStyle()` with `styleEqual()` is now chainable by default (thanks, @e-kennedy #632).
+
 ## BUG FIXES
 
 - Fix the issue that the first column can't be disabled from editing (thanks, @tsolloway #669, @haozhu233 #694).

--- a/R/format.R
+++ b/R/format.R
@@ -304,15 +304,17 @@ styleInterval = function(cuts, values) {
 
 #' @param levels a character vector of data values to be mapped (one-to-one) to
 #'   CSS values
-#' @param default a string used as the the default CSS value for values other than levels
+#' @param default a string or \code{NULL} used as the the default CSS value
+#'   for values other than levels. If \code{NULL}, the CSS value of non-matched
+#'   cells will be left unchanged.
 #' @export
 #' @rdname styleInterval
-styleEqual = function(levels, values, default = "") {
+styleEqual = function(levels, values, default = NULL) {
   n = length(levels)
   if (n != length(values))
     stop("length(levels) must be equal to length(values)")
-  if (!is.character(default) || length(default) != 1)
-    stop("default must be a string")
+  if (!is.null(default) && (!is.character(default) || length(default) != 1))
+    stop("default must be null or a string")
   if (n == 0) return("''")
   levels = jsValues(levels)
   values = jsValues(values)
@@ -320,7 +322,8 @@ styleEqual = function(levels, values, default = "") {
   for (i in seq_len(n)) {
     js = paste0(js, sprintf("value == %s ? %s : ", levels[i], values[i]))
   }
-  JS(paste0(js, jsValues(default)))
+  default = if (is.null(default)) 'value' else jsValues(default)
+  JS(paste0(js, default))
 }
 
 #' @param data a numeric vector whose range will be used for scaling the

--- a/man/styleInterval.Rd
+++ b/man/styleInterval.Rd
@@ -8,7 +8,7 @@
 \usage{
 styleInterval(cuts, values)
 
-styleEqual(levels, values, default = "")
+styleEqual(levels, values, default = NULL)
 
 styleColorBar(data, color, angle = 90)
 }
@@ -20,7 +20,9 @@ styleColorBar(data, color, angle = 90)
 \item{levels}{a character vector of data values to be mapped (one-to-one) to
 CSS values}
 
-\item{default}{a string used as the the default CSS value for values other than levels}
+\item{default}{a string or \code{NULL} used as the the default CSS value
+for values other than levels. If \code{NULL}, the CSS value of non-matched
+cells will be left unchanged.}
 
 \item{data}{a numeric vector whose range will be used for scaling the
 table data from 0-100 before being represented as color bars. A vector


### PR DESCRIPTION
Closes #632 

Although the default value of `default` is changed, I believe the current default behavior (left the non-matched cells' CSS value unchanged) is almost always desired.

## Example

```r
library(DT)
myTable = datatable(
  data.frame(V1 = c('a', 'b', 'c', 'd'), V2 = c('1', '2', '3', '4'))
)
myTable %>% formatStyle( 
  'V1',
  target = 'row',
  backgroundColor = styleEqual('a', 'red')
) %>% formatStyle(
  'V1',
  target = 'row',
  backgroundColor = styleEqual('c', 'green')
)
```

### Before the PR 

(Note the first row's color is blank, meaning it gets overridden by the 2nd `formatStyle()`)

<img width="530" alt="image" src="https://user-images.githubusercontent.com/8368933/63516828-58be4280-c520-11e9-990c-6a34c20af6e1.png">


### After the PR

(Works as expected)

<img width="531" alt="image" src="https://user-images.githubusercontent.com/8368933/63516787-48a66300-c520-11e9-8757-06a53533d3bd.png">
