### PR TITLE
Robuster footer selector when scrollX/Y is enabled

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.8.3
+Version: 0.8.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,10 @@
 ## BUG FIXES
 
 - Fix the issue that the first column can't be disabled from editing (thanks, @tsolloway #669, @haozhu233 #694).
+
 - Fix the issue that the filter boxes are not anchored to the corresponding value columns when there are many columns (thanks, @philibe, #554).
+
+- Column selection now works in `row+column` selection mode, when one of `scrollX` or `scrollY` is enabled (thanks, @akarslan #705).
 
 ## MINOR CHANGES
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1019,7 +1019,7 @@ HTMLWidgets.widget({
         if (selTarget === 'row+column') {
           $(table.columns().footer()).css('cursor', 'pointer');
         }
-        table.on('click.dt', selTarget === 'column' ? 'tbody td' : 'tfoot tr th', function() {
+        var callback = function() {
           var colIdx = selTarget === 'column' ? table.cell(this).index().column :
               $.inArray(this, table.columns().footer()),
               thisCol = $(table.column(colIdx).nodes());
@@ -1033,7 +1033,12 @@ HTMLWidgets.widget({
             selected2 = selMode === 'single' ? [colIdx] : unique(selected2.concat([colIdx]));
           }
           changeInput('columns_selected', selected2);
-        });
+        }
+        if (selTarget === 'column') {
+          $(table.table().body()).on('click.dt', 'td', callback);
+        } else {
+          $(table.table().footer()).on('click.dt', 'tr th', callback);
+        }
         changeInput('columns_selected', selected2);
         var selectCols = function() {
           table.columns().nodes().flatten().to$().removeClass(selClass);


### PR DESCRIPTION
Closes #705

When scrollX/Y is enabled, the column selection won't work in `row+column` mode. The reason is that the datatable library will seperate the footer from the body when there's a scroller. The old foot selector won't work somehow. This patch uses the datatables' api to select the footer, which should be robuster (at least ok for this case).

# Example Code

```r
library(shiny)
library(DT)

ui = basicPage(verbatimTextOutput('col_select'), DTOutput("tbl"))

server = function(input, output) {
  output$tbl = DT::renderDT({
    DT::datatable(
      iris,
      selection = list(mode = 'multiple', target = 'row+column'),
      options = list(scrollX = TRUE, scrollY = "300px")
    )
  })
  output$col_select = renderPrint({
    input$tbl_columns_selected
  })
}
shinyApp(ui = ui, server = server)
```

# Screenshot

<img width="1142" alt="image" src="https://user-images.githubusercontent.com/8368933/63873072-7c3a2f00-c9f1-11e9-9d73-2c468b245955.png">
