### PR TITLE
need to compare the escaped levels for `styleEqual()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.9.1
+Version: 0.9.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.10
 
+## BUG FIXES
+
+- Fix the issue that `styleEqual()` doesn't work expectedly for values contain special HTML character like `>` or `<` (thanks, @hjia222 #723).
 
 # CHANGES IN DT VERSION 0.9
 

--- a/R/format.R
+++ b/R/format.R
@@ -316,8 +316,8 @@ styleEqual = function(levels, values, default = NULL) {
   if (!is.null(default) && (!is.character(default) || length(default) != 1))
     stop("default must be null or a string")
   if (n == 0) return("''")
-  # because the data will be escaped by escapeData(), we need to compare
-  # the "escaped value" to the "levels" instead of the raw value
+  # because the data will be transformed by escapeData(), we need to compare
+  # the "escaped value" of the "levels" instead of the raw value
   if (is.character(levels) || is.factor(levels))
     levels = htmlEscape(levels)
   levels = jsValues(levels)

--- a/R/format.R
+++ b/R/format.R
@@ -316,6 +316,10 @@ styleEqual = function(levels, values, default = NULL) {
   if (!is.null(default) && (!is.character(default) || length(default) != 1))
     stop("default must be null or a string")
   if (n == 0) return("''")
+  # because the data will be escaped by escapeData(), we need to compare
+  # the "escaped value" to the "levels" instead of the raw value
+  if (is.character(levels) || is.factor(levels))
+    levels = htmlEscape(levels)
   levels = jsValues(levels)
   values = jsValues(values)
   js = ''


### PR DESCRIPTION
Closes #723 

## A minimal repro

```r
library(DT)
tbl = data.frame(
  A = c('a', 'b', '>a', "<b"),
  B = c('red', 'green', 'yellow', 'pink'),
  stringsAsFactors = FALSE
)
datatable(tbl) %>% 
  formatStyle("A", target = "row", backgroundColor = styleEqual(tbl$A, tbl$B))
```