### PR TITLE
Use Perl REs in filters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.11
 
+## NEW FEATURES
+
+- Filters now use Perl-compatible regular expressions (regexps), such as for lookround and negating assertions, see `help(regex)` or https://perldoc.perl.org/perlre.html. This may be most useful in columns (`DT::renderDataTable(filter = list(position = "top"))`), but also works in the global search (`DT::renderDataTable(options = list(dom = 'f')`) (@rfhb).
 
 # CHANGES IN DT VERSION 0.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # CHANGES IN DT VERSION 0.11
 
-## NEW FEATURES
+## MINOR CHANGES
 
-- Filters now use Perl-compatible regular expressions (regexps), such as for lookround and negating assertions, see `help(regex)` or https://perldoc.perl.org/perlre.html. This may be most useful in columns (`DT::renderDataTable(filter = list(position = "top"))`), but also works in the global search (`DT::renderDataTable(options = list(dom = 'f')`) (@rfhb).
+- In the server-side processing mode, filters now use Perl-compatible regular expressions (regexps), such as for lookround and negating assertions, see `help(regex)` or https://perldoc.perl.org/perlre.html. This may be most useful in columns (`DT::renderDataTable(filter = list(position = "top"), options = list(search = list(regex = TRUE))`), but also works in the global search (thanks, @rfhb, #727).
 
 # CHANGES IN DT VERSION 0.10
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -621,9 +621,9 @@ grep2 = function(pattern, x, ignore.case = FALSE, fixed = FALSE, ...) {
   }
   # when the user types in the search box, the regular expression may not be
   # complete before it is sent to the server, in which case we do not search
-  if (!fixed && inherits(try(grep(pattern, ''), silent = TRUE), 'try-error'))
+  if (!fixed && inherits(try(grep(pattern, '', perl = TRUE), silent = TRUE), 'try-error'))
     return(seq_along(x))
-  grep(pattern, x, ignore.case = ignore.case, fixed = fixed, ...)
+  grep(pattern, x, ignore.case = ignore.case, fixed = fixed, perl = TRUE, ...)
 }
 
 # filter a numeric/date/time vector using the search string "lower ... upper"


### PR DESCRIPTION
This PR is to extend the filtering by allowing extended regular expressions, which users will want to use for example to look ahead or behind, or to negate search terms.