### PR TITLE
should use levels() for factor column's filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.10.1
+Version: 0.10.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - In the server-side processing mode, filters now use Perl-compatible regular expressions (regexps), such as for lookround and negating assertions, see `help(regex)` or https://perldoc.perl.org/perlre.html. This may be most useful in columns (`DT::renderDataTable(filter = list(position = "top"), options = list(search = list(regex = TRUE))`), but also works in the global search (thanks, @rfhb, #727).
 
+- For a factor column, the choices of the filter now use the factor levels (#728).
+
 # CHANGES IN DT VERSION 0.10
 
 ## BUG FIXES

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -463,7 +463,7 @@ filterRow = function(
         d = c('true', 'false', if (any(is.na(d))) 'na')
       } else {
         t = 'factor'
-        d = sort(unique(d))
+        d = levels(d)
       }
       if (t != 'disabled') tags$div(
         tags$select(


### PR DESCRIPTION
Closes #726 

Not sure why the available option was `sort(unique(d))` but I think `levels(d)` sounds better since it's a factor.

```r
library(DT)
datatable(data.frame(a = factor(c("a", "b"), levels = c("a", "b", "c"))), filter = 'top')
```