### PR TITLE
Use current outputId in dataTableAjax() if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
 Suggests:
     knitr (>= 1.8),
     rmarkdown,
-    shiny (>= 1.1.0)
+    shiny (>= 1.2.0)
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -448,7 +448,9 @@ shinyFun = function(name) getFromNamespace(name, 'shiny')
 #'   list(value = 'FOO', regex = 'false'), length = 10, ...)}) that return the
 #'   filtered table result according to the DataTables Ajax request
 #' @param outputId the output ID of the table (the same ID passed to
-#'   \code{dataTableOutput()}; if missing, a random string)
+#'   \code{dataTableOutput()}; if missing, an attempt to infer it from
+#'   \code{session} is made. If it can't be inferred, a random id is
+#'   generated.)
 #' @references \url{https://rstudio.github.io/DT/server.html}
 #' @return A character string (an Ajax URL that can be queried by DataTables).
 #' @example inst/examples/ajax-shiny.R

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -424,8 +424,8 @@ shinyFun = function(name) getFromNamespace(name, 'shiny')
 
 # Works around the fact that session$getCurrentOutputInfo() in Shiny through
 # version 1.4 signals an error if there is no active output (the private field
-# ShinySession$currentOutputName is NULL).
-# Can be removed after https://github.com/rstudio/shiny/pull/2707 is released.
+# ShinySession$currentOutputName is NULL). Consider removing in the future
+# sometime after https://github.com/rstudio/shiny/pull/2707 is released.
 getCurrentOutputName <- function(session) {
   tryCatch(session$getCurrentOutputInfo()[["name"]], error = function(e) NULL)
 }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -457,7 +457,7 @@ dataTableAjax = function(session, data, rownames, filter = dataTablesFilter, out
 
   oop = options(stringsAsFactors = FALSE); on.exit(options(oop), add = TRUE)
 
-  if (missing(outputId)) outputId <- shiny::getCurrentOutputInfo()[["name"]]
+  if (missing(outputId)) outputId <- session$getCurrentOutputInfo()[["name"]]
   # abuse tempfile() to obtain a random id unique to this R session
   if (is.null(outputId)) outputId <- basename(tempfile(''))
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -422,6 +422,14 @@ invokeRemote = function(proxy, method, args = list()) {
 
 shinyFun = function(name) getFromNamespace(name, 'shiny')
 
+# Works around the fact that session$getCurrentOutputInfo() in Shiny through
+# version 1.4 signals an error if there is no active output (the private field
+# ShinySession$currentOutputName is NULL).
+# Can be removed after https://github.com/rstudio/shiny/pull/2707 is released.
+getCurrentOutputName <- function(session) {
+  tryCatch(session$getCurrentOutputInfo()[["name"]], error = function(e) NULL)
+}
+
 #' Register a data object in a shiny session for DataTables
 #'
 #' This function stores a data object in a shiny session and returns a URL that
@@ -459,7 +467,7 @@ dataTableAjax = function(session, data, rownames, filter = dataTablesFilter, out
 
   oop = options(stringsAsFactors = FALSE); on.exit(options(oop), add = TRUE)
 
-  if (missing(outputId)) outputId <- session$getCurrentOutputInfo()[["name"]]
+  if (missing(outputId)) outputId <- getCurrentOutputName(session)
   # abuse tempfile() to obtain a random id unique to this R session
   if (is.null(outputId)) outputId <- basename(tempfile(''))
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -457,8 +457,9 @@ dataTableAjax = function(session, data, rownames, filter = dataTablesFilter, out
 
   oop = options(stringsAsFactors = FALSE); on.exit(options(oop), add = TRUE)
 
+  if (missing(outputId)) outputId <- shiny::getCurrentOutputInfo()[["name"]]
   # abuse tempfile() to obtain a random id unique to this R session
-  if (missing(outputId)) outputId = basename(tempfile(''))
+  if (is.null(outputId)) outputId <- basename(tempfile(''))
 
   # deal with row names: rownames = TRUE or missing, use rownames(data)
   rn = if (missing(rownames) || isTRUE(rownames)) base::rownames(data) else {

--- a/inst/examples/ajax-shiny.R
+++ b/inst/examples/ajax-shiny.R
@@ -11,7 +11,7 @@ DTApp = function(data, ..., options = list()) {
     ),
     server = function(input, output, session) {
       options$serverSide = TRUE
-      options$ajax = list(url = dataTableAjax(session, data))
+      options$ajax = list(url = dataTableAjax(session, data, outputId = 'tbl'))
       # create a widget using an Ajax URL created above
       widget = datatable(data, ..., options = options)
       output$tbl = DT::renderDataTable(widget)


### PR DESCRIPTION
We noticed when testing [shinyloadtest](https://github.com/rstudio/shinyloadtest) that the shiny example [063-superzip-example](https://github.com/rstudio/shiny-examples/tree/master/063-superzip-example) didn't work.

It turned out the reason for the failure was non-determinism in the application. The example used `DT::dataTableAjax()` and [didn't supply an `outputId` parameter](https://github.com/rstudio/shiny-examples/blob/918cd7971353982e5f5256102b6b96a8a31959b5/063-superzip-example/server.R#L179), which caused DT to generate a random one using `tempfile()`.

We were able to fix the example by [simply specifying an outputId](https://github.com/rstudio/shiny-examples/pull/179), but it occurred to us that we could maybe prevent others from running into this problem by making a small enhancement to DT.

@jcheng5 pointed out that since `dataTableAjax()` was first written, Shiny (in 1.2.0) acquired the function `getCurrentOutputInfo()`, which can be used to obtain the name of the current output. This seems like a better default.

I wasn't sure if `dataTableAjax()` would always be called in a dynamic environment in which `shiny::getCurrentOutputInfo()[["name"]]` was non-`NULL`, so I added a NULL check and retained the `tempfile()` generation for that case. 