### PR TITLE
Rewrite the javascript library updating script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ inst/examples/random.R
 .*.Rnb.cached
 revdep/
 .DS_Store
+download/

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -30,10 +30,12 @@ encode_img = function(css) {
   w = setwd(dirname(css)); on.exit(setwd(w), add = TRUE)
   css = basename(css)
   x = readLines(css)
-  m = gregexpr('("?)[.][.][^"]+?[.]png\\1', x)
+  # match both "../images/xxx.png" and "images/xxx.png"
+  m = gregexpr('("|\']?)(\\.\\.)?[^"\']+?[.]png\\1', x)
   regmatches(x, m) = lapply(regmatches(x, m), function(ps) {
     if (length(ps) == 0) return(ps)
-    ps = gsub('^"|"$', '', ps)
+    # replace the first and the last `"` with empty
+    ps = gsub('^"|^\'|"$|\'$', '', ps)
     sapply(ps, knitr::image_uri)
   })
   writeLines(x, css)

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -4,13 +4,13 @@
 # 1. automate the download - maybe no need
 # 2. the datatables license file is not in the bundle anymore - do we really
 #    need that?
+# 3. should not update jquery.highlight.js because it's now manually maintained
 
 # note --------------------------------------------------------------------
 
 # This script is going to update
 # 1. datatables and its extentions' css and js files
 # 2. datatables' plugins' js files
-# 3. other dependencies like jquery.highlight.js
 
 # steps -------------------------------------------------------------------
 

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -69,7 +69,17 @@ keep_min = function(dir = dld_folder) {
   file.remove(x1[file.exists(x2)])
 }
 
+rm_version_number = function(dir = file.path(dld_folder, 'DataTables')) {
+  dirs = list.dirs(dir, recursive = FALSE)
+  pattern = '-\\d+[.]\\d+[.]\\d+$'
+  dirs = dirs[grepl(pattern, dirs)]
+  file.rename(dirs, gsub(pattern, '', dirs))
+}
+
 # clean up ----------------------------------------------------------------
+
+# remove the version number attached in the subfolder of DataTables
+invisible(rm_version_number())
 
 # only keep min files
 invisible(keep_min())

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -22,7 +22,7 @@
 
 # param -------------------------------------------------------------------
 
-dld_folder <- './download'
+dld_folder = './download'
 
 # utils -------------------------------------------------------------------
 
@@ -61,7 +61,7 @@ encode_img = function(css) {
 
 # if foo.min.js exists, remove foo.js; similar thing to .css
 keep_min = function(dir = dld_folder) {
-  dirs <- list.dirs(dir, recursive = FALSE)
+  dirs = list.dirs(dir, recursive = FALSE)
   invisible(lapply(dirs, keep_min))
   x1 = list.files(dir, '[.](css|js)$', full.names = TRUE)
   x2 = gsub('[.](css|js)$', '.min.\\1', x1)

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -203,24 +203,14 @@ local({
   }))
 })
 
-# update offical plugins
+# update plugins whose dependency is only one js file
 local({
-  plugins = DT:::available_plugins()
-  official_plugins = names(plugins)[plugins != 'searchHighlight']
-  invisible(lapply(official_plugins, function(plugin) {
-    file.copy(
-      dld_plugin_path(paste0(plugin, '.js')),
-      lib_plugin_path(plugin, paste0(basename(plugin), '.js')),
-      overwrite = TRUE
+  plugins = names(DT:::available_plugins())
+  lapply(plugins, function(plugin) {
+    copy_js_css_swf(
+      dld_plugin_path(plugin),
+      lib_plugin_path(plugin)
     )
-  }))
-})
-
-in_dir('features/searchHighlight', {
-  download.file('http://bartaz.github.io/sandbox.js/jquery.highlight.js', 'jquery.highlight.js')
-  file.copy(
-    c('dataTables.searchHighlight.css', 'dataTables.searchHighlight.min.js', 'jquery.highlight.js'),
-    dt_path('..', 'datatables-plugins', 'searchHighlight'), overwrite = TRUE
-  )
-  unlink('jquery.highlight.js')
+  })
+  invisible()
 })

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -18,8 +18,8 @@
 # 2. Go to https://datatables.net/download/index , click all the extentions,
 #    then go to Step 3 choose "minify" but not "concatenate". Put the files
 #    in "download/DataTables"
-# 3. Download all the content from https://github.com/DataTables/Plugins/ and
-#    put them under folder "download/Plugins"
+# 3. The plugins will be downloaded by this script automatically if
+#    "download/Plugins" doesn't exist
 # 4. Update the value of "DataTablesVersion" in "package.R"
 # 5. Run this script (note it will clean up the "download" folder afterwards
 #    so you might want to backup those files in case)
@@ -109,6 +109,17 @@ copy_js_css_swf = function(from_dir, to_dir) {
   file.copy(file.path(from_dir, js_css_files), to_files, overwrite = TRUE)
   invisible()
 }
+
+# download plugins --------------------------------------------------------
+
+if (!dir.exists(dld_plugin_path())) system2(
+  'git',
+  args = c(
+    'clone',
+    'https://github.com/DataTables/Plugins.git',
+    dld_plugin_path()
+  )
+)
 
 # clean up ----------------------------------------------------------------
 

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -1,27 +1,45 @@
-dt_path = local({
-  path = normalizePath('./inst/htmlwidgets/lib/datatables/')
-  function(...) {
-    path = file.path(path, ...)
-    if (!dir.exists(path))
-      dir.create(path)
-    path
-  }
-})
 
-owd = setwd('tools')
-ver = DT:::DataTablesVersion
-out = sprintf('DataTables-%s.zip', ver)
-unlink('DataTables*', recursive = TRUE)
-download.file(sprintf('http://datatables.net/releases/DataTables-%s.zip', ver), out, mode = 'wb')
-unzip(out)
+# note --------------------------------------------------------------------
+
+# This script is going to update
+# 1. datatables and its extentions' css and js files
+# 2. datatables' plugins' js files
+# 3. other dependencies like jquery.highlight.js
+
+# steps -------------------------------------------------------------------
+
+# 1. Create a folder "download" under the root of this project
+# 2. Go to https://datatables.net/download/index , click all the extentions,
+#    then go to Step 3 choose "minify" but not "concatenate". Put the files
+#    in "download/DataTables"
+# 3. Download all the content from https://github.com/DataTables/Plugins/ and
+#    put them under folder "download/Plugins"
+# 4. Update the value of "DataTablesVersion" in "package.R"
+# 5. Run this script (note it will clean up the "download" folder afterwards
+#    so you might want to backup those files in case)
+# 6. Manually test all the apps in "inst/examples"
+# 7. Rebuild the site
+
+# param -------------------------------------------------------------------
+
+dld_folder <- './download'
+
+# utils -------------------------------------------------------------------
+
+dt_path = function(...) {
+  path = file.path('./inst/htmlwidgets/lib/datatables/', ...)
+  path = normalizePath(path)
+  if (!dir.exists(path)) dir.create(path)
+  path
+}
+
 setwd = function(x) {
-  if (!dir.exists(x))
-    dir.create(x)
+  if (!dir.exists(x)) dir.create(x)
   base::setwd(x)
 }
+
 in_dir = function(dir, expr) {
-  if (!dir.exists(dir))
-    dir.create(dir, recursive = TRUE)
+  if (!dir.exists(dir)) dir.create(dir, recursive = TRUE)
   DT:::in_dir(dir, expr)
 }
 

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -125,6 +125,7 @@ invisible(lapply(
 ))
 
 # put JSZip, pdfmake js files to Buttons because it depends on those files
+# but those files are placed separately from Buttons
 local({
   jszip_files = list.files(
     dld_dt_path('JSZip'),

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -26,35 +26,18 @@
 # 6. Manually test all the apps in "inst/examples"
 # 7. Rebuild the site
 
-# param -------------------------------------------------------------------
+# utils -------------------------------------------------------------------
 
 dld_folder = function() {
   './download'
 }
+
 dld_dt_path = function(...) {
   file.path(dld_folder(), 'DataTables', ...)
 }
+
 dld_plugin_path = function(...) {
   file.path(dld_folder(), 'Plugins', ...)
-}
-
-# utils -------------------------------------------------------------------
-
-dt_path = function(...) {
-  path = file.path('./inst/htmlwidgets/lib/datatables/', ...)
-  path = normalizePath(path)
-  if (!dir.exists(path)) dir.create(path)
-  path
-}
-
-setwd = function(x) {
-  if (!dir.exists(x)) dir.create(x)
-  base::setwd(x)
-}
-
-in_dir = function(dir, expr) {
-  if (!dir.exists(dir)) dir.create(dir, recursive = TRUE)
-  DT:::in_dir(dir, expr)
 }
 
 # base64 encode images into CSS
@@ -217,4 +200,3 @@ local({
 
 # clean up download folder
 unlink(dld_folder(), recursive = TRUE)
-

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -129,8 +129,6 @@ copy_js_css_swf = function(from_dir, to_dir) {
 
 # clean up ----------------------------------------------------------------
 
-# remove the version number attached in the subfolder of DataTables
-rm_version_number(dld_dt_path())
 # remove the empty files if exists
 rm_empty_files(dld_folder())
 
@@ -142,6 +140,11 @@ invisible(lapply(
   list.files(dld_folder(), '[.]css$', recursive = TRUE, full.names = TRUE),
   encode_img
 ))
+
+# must be placed after `encode_img` because the css files may contain
+# images like "DataTables-1.10.20/images/sort_both.png"
+# remove the version number attached in the subfolder of DataTables
+rm_version_number(dld_dt_path())
 
 # put JSZip, pdfmake js files to Buttons because it depends on those files
 # but those files are placed separately from Buttons

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -60,12 +60,25 @@ encode_img = function(css) {
 }
 
 # if foo.min.js exists, remove foo.js; similar thing to .css
-keep_min = function(dir = '.') {
+keep_min = function(dir = dld_folder) {
+  dirs <- list.dirs(dir, recursive = FALSE)
+  invisible(lapply(dirs, keep_min))
   x1 = list.files(dir, '[.](css|js)$', full.names = TRUE)
   x2 = gsub('[.](css|js)$', '.min.\\1', x1)
   if (length(x1) == 0) return()
   file.remove(x1[file.exists(x2)])
 }
+
+# clean up ----------------------------------------------------------------
+
+# only keep min files
+invisible(keep_min())
+
+# replace the png files with base64 encode images
+invisible(lapply(
+  list.files(dld_folder, '[.]css$', recursive = TRUE, full.names = TRUE),
+  encode_img
+))
 
 setwd(file.path(sprintf('DataTables-%s', ver), 'media'))
 invisible({

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -160,40 +160,10 @@ local({
 # In addition, there's no license file bundled. Does this matter?
 copy_js_css_swf(dld_dt_path('DataTables'), lib_path('datatables'))
 
-# copy required files to the R package
-file.copy(
-  list.files('css', '[.]css$', full.names = TRUE), dt_path('css/'),
-  overwrite = TRUE
-)
-file.copy(
-  list.files('js', '[.]js$', full.names = TRUE), dt_path('js'),
-  overwrite = TRUE
-)
-file.copy('../license.txt', dt_path(), overwrite = TRUE)
-
 setwd('../extensions')
 
 extPath = dt_path('..', 'datatables-extensions')
 unlink(extPath, recursive = TRUE)
-
-# only keep css/ and js/ (plus swf/ for Buttons)
-invisible(lapply(list.files(), function(ext) {
-  dirs = file.path(ext, c('css', 'js', if (ext == 'Buttons') 'swf'))
-  allf = list.files(ext, all.files = TRUE, full.names = TRUE, no.. = TRUE)
-  unlink(allf[!(file_test('-d', allf) & (allf %in% dirs))], recursive = TRUE)
-  if (ext == 'Buttons') {
-    unlink(file.path(ext, 'css', '*.scss'))
-    for (u in c(
-      'https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js',
-      'https://raw.githubusercontent.com/bpampuch/pdfmake/0.1.18/build/pdfmake.min.js',
-      'https://raw.githubusercontent.com/bpampuch/pdfmake/0.1.18/build/vfs_fonts.js'
-    )) download.file(u, file.path(ext, 'js', basename(u)))
-  }
-  allf = list.files(ext, all.files = TRUE, recursive = TRUE, full.names = TRUE, no.. = TRUE)
-  allf = grep('[.](css|js|swf)$', allf, value = TRUE, invert = TRUE)
-  if (length(allf)) warning('These files may not be needed: ', paste(allf, collapse = ', '))
-  NULL
-}))
 
 file.rename('../extensions', '../datatables-extensions')
 file.copy('../datatables-extensions', dt_path('..'), overwrite = TRUE, recursive = TRUE)

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -214,3 +214,7 @@ local({
   })
   invisible()
 })
+
+# clean up download folder
+unlink(dld_folder(), recursive = TRUE)
+

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -28,12 +28,14 @@
 
 # param -------------------------------------------------------------------
 
-dld_folder = './download'
+dld_folder = function() {
+  './download'
+}
 dld_dt_path = function(...) {
-  file.path(dld_folder, 'DataTables', ...)
+  file.path(dld_folder(), 'DataTables', ...)
 }
 dld_plugin_path = function(...) {
-  file.path(dld_folder, 'Plugins', ...)
+  file.path(dld_folder(), 'Plugins', ...)
 }
 
 # utils -------------------------------------------------------------------
@@ -122,11 +124,11 @@ copy_js_css_swf = function(from_dir, to_dir) {
 rm_version_number(dld_dt_path())
 
 # only keep min files
-keep_min(dld_folder)
+keep_min(dld_folder())
 
 # replace the png files with base64 encode images
 invisible(lapply(
-  list.files(dld_folder, '[.]css$', recursive = TRUE, full.names = TRUE),
+  list.files(dld_folder(), '[.]css$', recursive = TRUE, full.names = TRUE),
   encode_img
 ))
 

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -28,9 +28,6 @@
 
 # param -------------------------------------------------------------------
 
-plugins = c('pagination', '')
-
-
 dld_folder = function() {
   './download'
 }
@@ -191,6 +188,17 @@ local({
 })
 
 # copy plugins
+local({
+  plugins = DT:::available_plugins()
+  official_plugins = names(plugins)[plugins != 'searchHighlight']
+  invisible(lapply(official_plugins, function(plugin) {
+    file.copy(
+      dld_plugin_path(paste0(plugin, '.js')),
+      lib_plugin_path(plugin, paste0(basename(plugin), '.js')),
+      overwrite = TRUE
+    )
+  }))
+})
 
 in_dir('features/searchHighlight', {
   download.file('http://bartaz.github.io/sandbox.js/jquery.highlight.js', 'jquery.highlight.js')

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -148,7 +148,7 @@ local({
   files = c(jszip_files, pdfmake_files)
   file.rename(
     files,
-    file.path(dld_dt_path('Buttons'), basename(files))
+    file.path(dld_dt_path('Buttons', 'js'), basename(files))
   )
 })
 

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -208,15 +208,3 @@ in_dir('features/searchHighlight', {
   )
   unlink('jquery.highlight.js')
 })
-
-file.copy(
-  c('sorting/natural.js'),
-  dt_path('..', 'datatables-plugins', 'natural'), overwrite = TRUE
-)
-
-file.copy(
-  c('dataRender/ellipsis.js'),
-  dt_path('..', 'datatables-plugins', 'ellipsis'), overwrite = TRUE
-)
-
-setwd(owd)

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -67,7 +67,7 @@ encode_img = function(css) {
 }
 
 # if foo.min.js exists, remove foo.js; similar thing to .css
-keep_min = function(dir = dld_folder) {
+keep_min = function(dir) {
   dirs = list.dirs(dir, recursive = FALSE)
   invisible(lapply(dirs, keep_min))
   x1 = list.files(dir, '[.](css|js)$', full.names = TRUE)
@@ -77,7 +77,7 @@ keep_min = function(dir = dld_folder) {
   invisible()
 }
 
-rm_version_number = function(dir = file.path(dld_folder, 'DataTables')) {
+rm_version_number = function(dir) {
   dirs = list.dirs(dir, recursive = FALSE)
   pattern = '-\\d+[.]\\d+[.]\\d+$'
   dirs = dirs[grepl(pattern, dirs)]
@@ -105,10 +105,10 @@ copy_js_css = function(from_dir, to_dir) {
 # clean up ----------------------------------------------------------------
 
 # remove the version number attached in the subfolder of DataTables
-rm_version_number()
+rm_version_number(dld_dt_path())
 
 # only keep min files
-keep_min()
+keep_min(dld_folder)
 
 # replace the png files with base64 encode images
 invisible(lapply(

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -168,6 +168,22 @@ local({
   unlink(c(dld_dt_path('JSZip'), dld_dt_path('pdfmake')), recursive = TRUE)
 })
 
+# put all the plugins under a folder with the same name if it only consists
+# a single js file
+local({
+  folders = list.dirs(dld_plugin_path(), recursive = FALSE)
+  create_folder_and_move = function(js_file, folder) {
+    dir = file.path(folder, gsub('[.]js$', '', js_file))
+    dir.create(dir)
+    file.rename(file.path(folder, js_file), file.path(dir, js_file))
+  }
+  lapply(folders, function(folder) {
+    js_files = list.files(folder, pattern = '[.]js$')
+    lapply(js_files, create_folder_and_move, folder = folder)
+  })
+  invisible()
+})
+
 # copy files --------------------------------------------------------------
 
 # update DataTables

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -115,19 +115,19 @@ invisible(lapply(
 # put JSZip, pdfmake js files to Buttons because it depends on those files
 local({
   jszip_files = list.files(
-    file.path(dld_folder, 'DataTables', 'JSZip'),
+    dld_dt_path('JSZip'),
     pattern = '[.]js$',
     full.names = TRUE
   )
   pdfmake_files = list.files(
-    file.path(dld_folder, 'DataTables', 'pdfmake'),
+    dld_dt_path('pdfmake'),
     pattern = '[.]js$',
     full.names = TRUE
   )
   files = c(jszip_files, pdfmake_files)
   file.rename(
     files,
-    file.path(file.path(dld_folder, 'DataTables', 'Buttons'), basename(files))
+    file.path(dld_dt_path('Buttons'), basename(files))
   )
 })
 

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -1,4 +1,10 @@
 
+# todo --------------------------------------------------------------------
+
+# 1. automate the download - maybe no need
+# 2. the datatables license file is not in the bundle anymore - do we really
+#    need that?
+
 # note --------------------------------------------------------------------
 
 # This script is going to update

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -89,9 +89,17 @@ lib_path = function(...) {
   file.path('inst/htmlwidgets/lib', ...)
 }
 
-copy_js_css = function(from_dir, to_dir) {
+lib_ext_path = function(...) {
+  lib_path('datatables-extensions', ...)
+}
+
+lib_plugin_path = function(...) {
+  lib_path('datatables-plugins', ...)
+}
+
+copy_js_css_swf = function(from_dir, to_dir) {
   js_css_files = list.files(
-    from_dir, pattern = '[.](css|js)$', recursive = TRUE
+    from_dir, pattern = '[.](css|js|swf)$', recursive = TRUE
   )
   to_files = file.path(to_dir, js_css_files)
   # create the sub-folder if doesn't exist
@@ -141,7 +149,7 @@ local({
 # dataTables.uikit.min.css, dataTables.uikit.min.js, dataTables.dataTables.min.js
 # may be obsolete
 # In addition, there's no license file bundled. Does this matter?
-copy_js_css(dld_dt_path('DataTables'), lib_path('datatables'))
+copy_js_css_swf(dld_dt_path('DataTables'), lib_path('datatables'))
 
 # copy required files to the R package
 file.copy(

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -90,6 +90,24 @@ invisible(lapply(
   encode_img
 ))
 
+# put JSZip, pdfmake js files to Buttons because it depends on those files
+local({
+  jszip_files = list.files(
+    file.path(dld_folder, 'DataTables', 'JSZip'),
+    pattern = '[.]js$',
+    full.names = TRUE
+  )
+  pdfmake_files = list.files(
+    file.path(dld_folder, 'DataTables', 'pdfmake'),
+    pattern = '[.]js$',
+    full.names = TRUE
+  )
+  files = c(jszip_files, pdfmake_files)
+  file.rename(
+    files,
+    file.path(file.path(dld_folder, 'DataTables', 'Buttons'), basename(files))
+  )
+})
 # copy required files to the R package
 file.copy(
   list.files('css', '[.]css$', full.names = TRUE), dt_path('css/'),

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -63,6 +63,7 @@ encode_img = function(css) {
     sapply(ps, knitr::image_uri)
   })
   writeLines(x, css)
+  invisible()
 }
 
 # if foo.min.js exists, remove foo.js; similar thing to .css
@@ -73,6 +74,7 @@ keep_min = function(dir = dld_folder) {
   x2 = gsub('[.](css|js)$', '.min.\\1', x1)
   if (length(x1) == 0) return()
   file.remove(x1[file.exists(x2)])
+  invisible()
 }
 
 rm_version_number = function(dir = file.path(dld_folder, 'DataTables')) {
@@ -80,6 +82,7 @@ rm_version_number = function(dir = file.path(dld_folder, 'DataTables')) {
   pattern = '-\\d+[.]\\d+[.]\\d+$'
   dirs = dirs[grepl(pattern, dirs)]
   file.rename(dirs, gsub(pattern, '', dirs))
+  invisible()
 }
 
 lib_path = function(...) {
@@ -95,16 +98,17 @@ copy_js_css = function(from_dir, to_dir) {
   lapply(Filter(Negate(dir.exists), dirname(to_files)), function(dir) {
     dir.create(dir, recursive = TRUE, showWarnings = FALSE)
   })
-  invisible(file.copy(file.path(from_dir, js_css_files), to_files, overwrite = TRUE))
+  file.copy(file.path(from_dir, js_css_files), to_files, overwrite = TRUE)
+  invisible()
 }
 
 # clean up ----------------------------------------------------------------
 
 # remove the version number attached in the subfolder of DataTables
-invisible(rm_version_number())
+rm_version_number()
 
 # only keep min files
-invisible(keep_min())
+keep_min()
 
 # replace the png files with base64 encode images
 invisible(lapply(

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -170,13 +170,13 @@ local({
 
 # copy files --------------------------------------------------------------
 
-# copy DataTables
+# update DataTables
 # dataTables.uikit.min.css, dataTables.uikit.min.js, dataTables.dataTables.min.js
 # may be obsolete
 # In addition, there's no license file bundled. Does this matter?
 copy_js_css_swf(dld_dt_path('DataTables'), lib_path('datatables'))
 
-# copy extensions
+# update extensions
 local({
   # the only not-extension folders are jszip and pdfmake, which should have
   # been deleted in the above steps
@@ -187,7 +187,7 @@ local({
   }))
 })
 
-# copy plugins
+# update offical plugins
 local({
   plugins = DT:::available_plugins()
   official_plugins = names(plugins)[plugins != 'searchHighlight']

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -80,14 +80,6 @@ invisible(lapply(
   encode_img
 ))
 
-setwd(file.path(sprintf('DataTables-%s', ver), 'media'))
-invisible({
-  lapply(list.dirs('..'), keep_min)
-  lapply(list.files('..', '[.]css$', recursive = TRUE, full.names = TRUE), encode_img)
-})
-unlink('css/jquery.dataTables_themeroller.css')
-unlink('js/jquery.js')
-
 # copy required files to the R package
 file.copy(
   list.files('css', '[.]css$', full.names = TRUE), dt_path('css/'),

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -28,6 +28,9 @@
 
 # param -------------------------------------------------------------------
 
+plugins = c('pagination', '')
+
+
 dld_folder = function() {
   './download'
 }
@@ -187,16 +190,7 @@ local({
   }))
 })
 
-setwd('../extensions')
-
-extPath = dt_path('..', 'datatables-extensions')
-unlink(extPath, recursive = TRUE)
-
-file.rename('../extensions', '../datatables-extensions')
-file.copy('../datatables-extensions', dt_path('..'), overwrite = TRUE, recursive = TRUE)
-
-setwd('../../Plugins/')
-system2('git', 'pull origin master')
+# copy plugins
 
 in_dir('features/searchHighlight', {
   download.file('http://bartaz.github.io/sandbox.js/jquery.highlight.js', 'jquery.highlight.js')

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -150,6 +150,8 @@ local({
     files,
     file.path(dld_dt_path('Buttons', 'js'), basename(files))
   )
+  # so that all other folders except DataTables are extensions
+  unlink(c(dld_dt_path('JSZip'), dld_dt_path('pdfmake')), recursive = TRUE)
 })
 
 # copy files --------------------------------------------------------------

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -85,6 +85,15 @@ keep_min = function(dir) {
   invisible()
 }
 
+# sometimes the bundle downloaded from datatables.net contains empty
+# files (seems caused by the downloading set-up error) so we just
+# remove those
+rm_empty_files = function(dir) {
+  files = list.files(dir, recursive = TRUE, full.names = TRUE)
+  empty_files = files[file.size(files) == 0]
+  unlink(empty_files)
+}
+
 rm_version_number = function(dir) {
   dirs = list.dirs(dir, recursive = FALSE)
   pattern = '-\\d+[.]\\d+[.]\\d+$'
@@ -122,6 +131,8 @@ copy_js_css_swf = function(from_dir, to_dir) {
 
 # remove the version number attached in the subfolder of DataTables
 rm_version_number(dld_dt_path())
+# remove the empty files if exists
+rm_empty_files(dld_folder())
 
 # only keep min files
 keep_min(dld_folder())

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -162,6 +162,17 @@ local({
 # In addition, there's no license file bundled. Does this matter?
 copy_js_css_swf(dld_dt_path('DataTables'), lib_path('datatables'))
 
+# copy extensions
+local({
+  # the only not-extension folders are jszip and pdfmake, which should have
+  # been deleted in the above steps
+  exts = list.dirs(dld_dt_path(), recursive = FALSE, full.names = FALSE)
+  exts = setdiff(exts, 'DataTables')
+  invisible(lapply(exts, function(ext) {
+    copy_js_css_swf(dld_dt_path(ext), lib_ext_path(ext))
+  }))
+})
+
 setwd('../extensions')
 
 extPath = dt_path('..', 'datatables-extensions')

--- a/tools/update_DT.R
+++ b/tools/update_DT.R
@@ -23,6 +23,12 @@
 # param -------------------------------------------------------------------
 
 dld_folder = './download'
+dld_dt_path = function(...) {
+  file.path(dld_folder, 'DataTables', ...)
+}
+dld_plugin_path = function(...) {
+  file.path(dld_folder, 'Plugins', ...)
+}
 
 # utils -------------------------------------------------------------------
 
@@ -76,6 +82,22 @@ rm_version_number = function(dir = file.path(dld_folder, 'DataTables')) {
   file.rename(dirs, gsub(pattern, '', dirs))
 }
 
+lib_path = function(...) {
+  file.path('inst/htmlwidgets/lib', ...)
+}
+
+copy_js_css = function(from_dir, to_dir) {
+  js_css_files = list.files(
+    from_dir, pattern = '[.](css|js)$', recursive = TRUE
+  )
+  to_files = file.path(to_dir, js_css_files)
+  # create the sub-folder if doesn't exist
+  lapply(Filter(Negate(dir.exists), dirname(to_files)), function(dir) {
+    dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  })
+  invisible(file.copy(file.path(from_dir, js_css_files), to_files, overwrite = TRUE))
+}
+
 # clean up ----------------------------------------------------------------
 
 # remove the version number attached in the subfolder of DataTables
@@ -108,6 +130,15 @@ local({
     file.path(file.path(dld_folder, 'DataTables', 'Buttons'), basename(files))
   )
 })
+
+# copy files --------------------------------------------------------------
+
+# copy DataTables
+# dataTables.uikit.min.css, dataTables.uikit.min.js, dataTables.dataTables.min.js
+# may be obsolete
+# In addition, there's no license file bundled. Does this matter?
+copy_js_css(dld_dt_path('DataTables'), lib_path('datatables'))
+
 # copy required files to the R package
 file.copy(
   list.files('css', '[.]css$', full.names = TRUE), dt_path('css/'),


### PR DESCRIPTION
(The number of files changed should be only one after #735 gets merged)

Despite that with not-too-much efforts, this script can be fully automated (we can read the latest extension's version number and then generate the downloading URL), since we only update the library occasionally, I'm ok by clicking and download manually from datatables.net.

