### PR TITLE
should use scroller = TRUE to initialize Scroller extension

### DIFF
--- a/inst/examples/DT-scroller/server.R
+++ b/inst/examples/DT-scroller/server.R
@@ -17,7 +17,8 @@ shinyServer(function(input, output) {
     options = list(
       ajax = 'large.txt',
       deferRender = TRUE,
-      dom = 'frtiS',
+      dom = 'frti',
+      scroller = TRUE,
       scrollY = 200,
       scrollCollapse = TRUE
     )


### PR DESCRIPTION
From https://cdn.datatables.net/scroller/2.0.0/ we know that using `dom = 'S'` is deprecated after Scroller version 2.0.0 

> Note also that the option to initialise Scroller through the dom option (with the S feature) has been removed, and scroller should be used instead.


