### PR TITLE
Warn if Select ext is used in server mode or with selection enabled

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -66,7 +66,10 @@
 #'   \code{target} in the list can be \code{'column'} to enable column
 #'   selection, or \code{'row+column'} to make it possible to select both rows
 #'   and columns (click on the footer to select columns), or \code{'cell'} to
-#'   select cells
+#'   select cells. Note that DT has its own selection implementation and doesn't
+#'   use the Select extension because the latter is limited to be used in the
+#'   client-side processing mode (i.e., server = FALSE). If you really want to
+#'   use the Select extension please set this argument to \code{'none'}
 #' @param extensions a character vector of the names of the DataTables
 #'   extensions (\url{https://datatables.net/extensions/index})
 #' @param plugins a character vector of the names of DataTables plug-ins

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -264,21 +264,11 @@ datatable = function(
   }
 
   # warn if the Select ext is used but selection is not set to none
-  # and remove the Select extensions
   if ('Select' %in% extensions && selection$mode != 'none') warning(
     "The Select extension can't work properly with DT's own ",
     "selection implemention and is only recommended in the client mode. ",
-    "Please set `selection = 'none'` if you really want to use the Select",
-    "extension.", immediate. = TRUE
-  )
-  # we need to warn the use of "Select" extension in the server-side processing
-  # mode since right now there's no good API of supporting the server mode.
-  # see [this comment](https://github.com/rstudio/DT/pull/717#issuecomment-568228919)
-  if ('Select' %in% extensions && isTRUE(server)) warning(
-    "The Select extension is not able to work with the server-side ",
-    "processing mode. Please either set `server = FALSE` or use ",
-    "DT's own selection implementations. See the selection argument ",
-    "in ?datatable().", immediate. = TRUE
+    "If you really want to use the Select extension please set ",
+    "`selection = 'none'`", immediate. = TRUE
   )
 
   deps = list(DTDependency(style))

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -260,6 +260,24 @@ datatable = function(
     params$selection = selection
   }
 
+  # warn if the Select ext is used but selection is not set to none
+  # and remove the Select extensions
+  if ('Select' %in% extensions && selection$mode != 'none') warning(
+    "The Select extension can't work properly with DT's own ",
+    "selection implemention and is only recommended in the client mode. ",
+    "Please set `selection = 'none'` if you really want to use the Select",
+    "extension.", immediate. = TRUE
+  )
+  # we need to warn the use of "Select" extension in the server-side processing
+  # mode since right now there's no good API of supporting the server mode.
+  # see [this comment](https://github.com/rstudio/DT/pull/717#issuecomment-568228919)
+  if ('Select' %in% extensions && isTRUE(server)) warning(
+    "The Select extension is not able to work with the server-side ",
+    "processing mode. Please either set `server = FALSE` or use ",
+    "DT's own selection implementations. See the selection argument ",
+    "in ?datatable().", immediate. = TRUE
+  )
+
   deps = list(DTDependency(style))
   deps = c(deps, unlist(
     lapply(extensions, extDependency, style, options),

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -67,9 +67,9 @@
 #'   selection, or \code{'row+column'} to make it possible to select both rows
 #'   and columns (click on the footer to select columns), or \code{'cell'} to
 #'   select cells. Note that DT has its own selection implementation and doesn't
-#'   use the Select extension because the latter is limited to be used in the
-#'   client-side processing mode (i.e., server = FALSE). If you really want to
-#'   use the Select extension please set this argument to \code{'none'}
+#'   use the Select extension because the latter doesn't support the
+#'   server-side processing mode well. Please set this argument to \code{'none'}
+#'   if you really want to use the Select extension.
 #' @param extensions a character vector of the names of the DataTables
 #'   extensions (\url{https://datatables.net/extensions/index})
 #' @param plugins a character vector of the names of DataTables plug-ins

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -116,6 +116,21 @@ renderDataTable = function(
         options$ajax$url = url
       }
       instance$x$options = fixServerOptions(options)
+
+      # We need to warn the use of "Select" extension in the server-side processing
+      # mode since right now there's no good way of supporting the server mode.
+      # More specifically, the Select ext can't remember the cross-page selections
+      # because the javascript implementation doesn't take the server mode into account.
+      # Until that gets changed, we are not able to integrate the Select ext with DT's
+      # own implementations.
+      if ('Select' %in% as.character(instance$x$extensions)) warning(
+        "The Select extension is not able to work with the server-side ",
+        "processing mode properly. It's recommended to use the Select extension ",
+        "only in the client-side processing mode (by setting `server = FALSE` ",
+        "in `DT::renderDT()`) or use DT's own selection implementations (",
+        "see the `selection` argument in ?DT::datatable).",
+        immediate. = TRUE, call. = FALSE
+      )
     }
 
     instance

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -108,9 +108,9 @@ selected = c(1, 3, 8), target = 'row')} to pre-select rows; the element
 selection, or \code{'row+column'} to make it possible to select both rows
 and columns (click on the footer to select columns), or \code{'cell'} to
 select cells. Note that DT has its own selection implementation and doesn't
-use the Select extension because the latter is limited to be used in the
-client-side processing mode (i.e., server = FALSE). If you really want to
-use the Select extension please set this argument to \code{'none'}}
+use the Select extension because the latter doesn't support the
+server-side processing mode well. Please set this argument to \code{'none'}
+if you really want to use the Select extension.}
 
 \item{extensions}{a character vector of the names of the DataTables
 extensions (\url{https://datatables.net/extensions/index})}

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -107,7 +107,10 @@ selected = c(1, 3, 8), target = 'row')} to pre-select rows; the element
 \code{target} in the list can be \code{'column'} to enable column
 selection, or \code{'row+column'} to make it possible to select both rows
 and columns (click on the footer to select columns), or \code{'cell'} to
-select cells}
+select cells. Note that DT has its own selection implementation and doesn't
+use the Select extension because the latter is limited to be used in the
+client-side processing mode (i.e., server = FALSE). If you really want to
+use the Select extension please set this argument to \code{'none'}}
 
 \item{extensions}{a character vector of the names of the DataTables
 extensions (\url{https://datatables.net/extensions/index})}


### PR DESCRIPTION
Now I think we should only support the Select ext in the client-processing mode (see #717 for the reason).

So I'm going to split  three patches:

1. Be clear that we only recommend the Select ext is used in the client mode and the user should set `selection = 'none'`
1. Add the support of the Select ext - so that the rows/columns/cells_selected should get updated according to the selection
1. Further improvement on the current selection implementations like `shift` for cells and columns

And this is the first one.

Thanks.

