### PR TITLE
Support Select ext for the client-side processing mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.11.1
+Version: 0.11.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN DT VERSION 0.12
 
+## NEW FEATURES
 
+- Support the Select extension on the client-side processing mode (thanks, @shrektan, #744).
 
 # CHANGES IN DT VERSION 0.11
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -890,6 +890,40 @@ HTMLWidgets.widget({
       return {row: info.row, col: info.column};
     }
 
+    // a flag to indicates if select extension is initialized or not
+    var flagSelectExt = table.settings()[0]._select !== undefined;
+    // the Select extension should only be used in the client mode and
+    // when the selection.mode is set to none
+    if (data.selection.mode === 'none' && !server && flagSelectExt) {
+      var updateRowsSelected = function() {
+        var rows = table.rows({selected: true});
+        var selected = [];
+        $.each(rows.indexes().toArray(), function(i, v) {
+          selected.push(v + 1);
+        });
+        changeInput('rows_selected', selected);
+      }
+      var updateColsSelected = function() {
+        var columns = table.columns({selected: true});
+        changeInput('columns_selected', columns.indexes().toArray());
+      }
+      var updateCellsSelected = function() {
+        var cells = table.cells({selected: true});
+        var selected = [];
+        cells.every(function() {
+          var row = this.index().row;
+          var col = this.index().column;
+          selected = selected.concat([[row + 1, col]]);
+        });
+        changeInput('cells_selected', transposeArray2D(selected), 'shiny.matrix');
+      }
+      table.on('select deselect', function(e, dt, type, indexes) {
+        updateRowsSelected();
+        updateColsSelected();
+        updateCellsSelected();
+      })
+    }
+
     var selMode = data.selection.mode, selTarget = data.selection.target;
     if (inArray(selMode, ['single', 'multiple'])) {
       var selClass = data.style === 'bootstrap' ? 'active' : 'selected';


### PR DESCRIPTION
The Select extension on the client mode will now trigger the updating of the server-side values like rows/columns/cells_selected.

## The example app

```r
library(shiny)

ui = fluidPage(
  radioButtons('style', 'style', c('os', 'multi', 'single', 'multi+shift'), inline = TRUE),
  radioButtons('items', 'items', c('row', 'column', 'cell'), inline = TRUE),
  DT::DTOutput('tbl'),
  verbatimTextOutput('print')
)
server = function(input, output) {
  output$print = renderPrint({
    print(input$tbl_rows_selected)
    print(input$tbl_columns_selected)
    print(input$tbl_cells_selected)
  })
  output$tbl = DT::renderDT(DT::datatable(
    selection = 'none', 
    iris, extensions = c('Select', 'Buttons'), options = list(
      select = list(style = input$style, items = input$items),
      dom = 'Blfrtip',
      rowId = 0,
      buttons = c('selectAll', 'selectNone', 'selectRows', 'selectColumns', 'selectCells')
    )
  ), server = FALSE)
}
runApp(list(ui = ui, server = server), port = 5759)
```
