### PR TITLE
Add Bootstrap4 extra css file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - Fix a bug that `addRow()` can't add a `data.table` row to the proxy (thanks, @sifodia @shrektan, #760 #761).
 
+- Now DT displays the column alignment and the selection style correctly under the bootstrap4 theme (thanks, @pjvandam @shrektan, #601 #765).
+
 # CHANGES IN DT VERSION 0.11
 
 ## NEW FEATURES

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -623,6 +623,7 @@ DTDependency = function(style) {
     css = sprintf('dataTables.%s.min.css', style)
     # patch the Bootstrap style
     if (style == 'bootstrap') css = c(css, 'dataTables.bootstrap.extra.css')
+    if (style == 'bootstrap4') css = c(css, 'dataTables.bootstrap4.extra.css')
   }
   htmlDependency(
     depName(style, 'dt-core'), DataTablesVersion, src = depPath('datatables'),

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -932,7 +932,7 @@ HTMLWidgets.widget({
 
     var selMode = data.selection.mode, selTarget = data.selection.target;
     if (inArray(selMode, ['single', 'multiple'])) {
-      var selClass = data.style === 'bootstrap' ? 'active' : 'selected';
+      var selClass = inArray(data.style, ['bootstrap', 'bootstrap4']) ? 'active' : 'selected';
       var selected = data.selection.selected, selected1, selected2;
       // selected1: row indices; selected2: column indices
       if (selected === null) {

--- a/inst/htmlwidgets/lib/datatables/css/dataTables.bootstrap4.extra.css
+++ b/inst/htmlwidgets/lib/datatables/css/dataTables.bootstrap4.extra.css
@@ -1,0 +1,78 @@
+table.dataTable th.dt-left,
+table.dataTable td.dt-left {
+  text-align: left;
+}
+table.dataTable th.dt-center,
+table.dataTable td.dt-center,
+table.dataTable td.dataTables_empty {
+  text-align: center;
+}
+table.dataTable th.dt-right,
+table.dataTable td.dt-right {
+  text-align: right;
+}
+table.dataTable th.dt-justify,
+table.dataTable td.dt-justify {
+  text-align: justify;
+}
+table.dataTable th.dt-nowrap,
+table.dataTable td.dt-nowrap {
+  white-space: nowrap;
+}
+table.dataTable thead th.dt-head-left,
+table.dataTable thead td.dt-head-left,
+table.dataTable tfoot th.dt-head-left,
+table.dataTable tfoot td.dt-head-left {
+  text-align: left;
+}
+table.dataTable thead th.dt-head-center,
+table.dataTable thead td.dt-head-center,
+table.dataTable tfoot th.dt-head-center,
+table.dataTable tfoot td.dt-head-center {
+  text-align: center;
+}
+table.dataTable thead th.dt-head-right,
+table.dataTable thead td.dt-head-right,
+table.dataTable tfoot th.dt-head-right,
+table.dataTable tfoot td.dt-head-right {
+  text-align: right;
+}
+table.dataTable thead th.dt-head-justify,
+table.dataTable thead td.dt-head-justify,
+table.dataTable tfoot th.dt-head-justify,
+table.dataTable tfoot td.dt-head-justify {
+  text-align: justify;
+}
+table.dataTable thead th.dt-head-nowrap,
+table.dataTable thead td.dt-head-nowrap,
+table.dataTable tfoot th.dt-head-nowrap,
+table.dataTable tfoot td.dt-head-nowrap {
+  white-space: nowrap;
+}
+table.dataTable tbody th.dt-body-left,
+table.dataTable tbody td.dt-body-left {
+  text-align: left;
+}
+table.dataTable tbody th.dt-body-center,
+table.dataTable tbody td.dt-body-center {
+  text-align: center;
+}
+table.dataTable tbody th.dt-body-right,
+table.dataTable tbody td.dt-body-right {
+  text-align: right;
+}
+table.dataTable tbody th.dt-body-justify,
+table.dataTable tbody td.dt-body-justify {
+  text-align: justify;
+}
+table.dataTable tbody th.dt-body-nowrap,
+table.dataTable tbody td.dt-body-nowrap {
+  white-space: nowrap;
+}
+.table.dataTable tbody td.active, .table.dataTable tbody tr.active td {
+	background-color: #0075b0;
+	color: white;
+}
+.dataTables_scrollBody .dataTables_sizing {
+  visibility: hidden;
+}

--- a/inst/htmlwidgets/lib/datatables/css/dataTables.bootstrap4.extra.css
+++ b/inst/htmlwidgets/lib/datatables/css/dataTables.bootstrap4.extra.css
@@ -70,7 +70,7 @@ table.dataTable tbody td.dt-body-nowrap {
   white-space: nowrap;
 }
 .table.dataTable tbody td.active, .table.dataTable tbody tr.active td {
-	background-color: #0075b0;
+	background-color: #007bff;
 	color: white;
 }
 .dataTables_scrollBody .dataTables_sizing {


### PR DESCRIPTION
Closes #601

So that column alignment and selection style can be displayed correctly.

```r
library(shiny)
library(DT)

shinyApp(
  # note you can't use any shiny UIs like fluidPage() because
  # shiny is currently implemented in bootstrap3 and it means using 
  # any UI will depends on the bootstrap3 css file which will confilict
  # with the bootstrap4 CSS file and leads to weird outlook
  ui = tagList(
    tags$head(
      tags$link(
        rel="stylesheet",
        href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.css"
      )
    ),
    DT::dataTableOutput('tbl')
  ),
  server = function(input, output) {
    output$tbl = DT::renderDataTable(
      iris, style = "bootstrap4", options = list(lengthChange = FALSE)
    )
  }
)
```

<img width="763" alt="image" src="https://user-images.githubusercontent.com/8368933/73598571-0f652b00-4575-11ea-86bc-dbecdd04fd1d.png">
