### PR TITLE
Tweak the selection color of bootstrap theme

### DIFF
--- a/inst/htmlwidgets/lib/datatables/css/dataTables.bootstrap.extra.css
+++ b/inst/htmlwidgets/lib/datatables/css/dataTables.bootstrap.extra.css
@@ -70,7 +70,7 @@ table.dataTable tbody td.dt-body-nowrap {
   white-space: nowrap;
 }
 .table.dataTable tbody td.active, .table.dataTable tbody tr.active td {
-	background-color: #0075b0;
+	background-color: #337ab7;
 	color: white;
 }
 .dataTables_scrollBody .dataTables_sizing {


### PR DESCRIPTION
The selection color in bootstrap should be the same as the color of the page button.

The two colors are very close in fact but I guess the intention is to use the identical color. 

### BEFORE

<img width="867" alt="截屏2020-02-02上午4 42 17" src="https://user-images.githubusercontent.com/8368933/73598729-d928ab00-4576-11ea-8b75-65c35aad9384.png">

### AFTER

<img width="858" alt="截屏2020-02-02上午4 43 12" src="https://user-images.githubusercontent.com/8368933/73598731-e2197c80-4576-11ea-92df-e6fccd0e0431.png">
