### PR TITLE
Use column.render option to implement formatXXX()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.12.2
+Version: 0.12.3
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Fix a bug that on Windows, rmarkdown can't render a file that contains DT with PDF download button enabled (thanks, @mfherman @shrektan, #774)
 
+## NEW FEATURES
+
+- All the formatting functions except `formatStyle()` now support the `Responsive` plugin (thanks, @shrektan, #777)
+
 # CHANGES IN DT VERSION 0.12
 
 ## NEW FEATURES

--- a/R/format.R
+++ b/R/format.R
@@ -3,8 +3,10 @@ formatColumns = function(table, columns, template, ...) {
   x = table$x
   colnames = base::attr(x, 'colnames', exact = TRUE)
   rownames = base::attr(x, 'rownames', exact = TRUE)
-  x$options$rowCallback = appendFormatter(
-    x$options$rowCallback, columns, colnames, rownames, template, ...
+  x$options$columnDefs = append(
+    x$options$columnDefs, colFormatter(
+      columns, colnames, rownames, template, ...
+    )
   )
   table$x = x
   table
@@ -167,15 +169,10 @@ name2int = function(name, names, rownames) {
   i
 }
 
-appendFormatter = function(js, name, names, rownames = TRUE, template, ...) {
-  js = if (length(js) == 0) c('function(row, data) {', '}') else {
-    unlist(strsplit(as.character(js), '\n'))
-  }
+colFormatter = function(name, names, rownames = TRUE, template, ...) {
   i = name2int(name, names, rownames)
-  JS(append(
-    js, after = length(js) - 1,
-    template(i, ..., names, rownames)
-  ))
+  js = sprintf("function(data, type, row, meta) { return %s }", template(...))
+  list(list(targets = i, render = JS(js)))
 }
 
 tplCurrency = function(currency, interval, mark, digits, dec.mark, before, ...) {

--- a/R/format.R
+++ b/R/format.R
@@ -178,45 +178,45 @@ appendFormatter = function(js, name, names, rownames = TRUE, template, ...) {
   ))
 }
 
-tplCurrency = function(cols, currency, interval, mark, digits, dec.mark, before, ...) {
+tplCurrency = function(currency, interval, mark, digits, dec.mark, before, ...) {
   sprintf(
-    "DTWidget.formatCurrency(this, row, data, %d, %s, %d, %d, %s, %s, %s);",
-    cols, jsValues(currency), digits, interval, jsValues(mark), jsValues(dec.mark),
+    "DTWidget.formatCurrency(data, %s, %d, %d, %s, %s, %s);",
+    jsValues(currency), digits, interval, jsValues(mark), jsValues(dec.mark),
     jsValues(before)
   )
 }
 
-tplString = function(cols, prefix, suffix, ...) {
+tplString = function(prefix, suffix, ...) {
   sprintf(
-    "DTWidget.formatString(this, row, data, %d, %s, %s);",
-    cols, jsValues(prefix), jsValues(suffix)
+    "DTWidget.formatString(data, %s, %s);",
+    jsValues(prefix), jsValues(suffix)
   )
 }
 
-tplPercentage = function(cols, digits, interval, mark, dec.mark, ...) {
+tplPercentage = function(digits, interval, mark, dec.mark, ...) {
   sprintf(
-    "DTWidget.formatPercentage(this, row, data, %d, %d, %d, %s, %s);",
-    cols, digits, interval, jsValues(mark), jsValues(dec.mark)
+    "DTWidget.formatPercentage(data, %d, %d, %s, %s);",
+    digits, interval, jsValues(mark), jsValues(dec.mark)
   )
 }
 
-tplRound = function(cols, digits, interval, mark, dec.mark, ...) {
+tplRound = function(digits, interval, mark, dec.mark, ...) {
   sprintf(
-    "DTWidget.formatRound(this, row, data, %d, %d, %d, %s, %s);",
-    cols, digits, interval, jsValues(mark), jsValues(dec.mark)
+    "DTWidget.formatRound(data, %d, %d, %s, %s);",
+    digits, interval, jsValues(mark), jsValues(dec.mark)
   )
 }
 
-tplSignif = function(cols, digits, interval, mark, dec.mark, ...) {
+tplSignif = function(digits, interval, mark, dec.mark, ...) {
   sprintf(
-    "DTWidget.formatSignif(this, row, data, %d, %d, %d, %s, %s);",
-    cols, digits, interval, jsValues(mark), jsValues(dec.mark)
+    "DTWidget.formatSignif(data, %d, %d, %s, %s);",
+    digits, interval, jsValues(mark), jsValues(dec.mark)
   )
 }
 
-tplDate = function(cols, method, params, ...) {
+tplDate = function(method, params, ...) {
   params = if (length(params) > 0) paste(',', toJSON(params)) else ''
-  sprintf("DTWidget.formatDate(this, row, data, %d, %s%s);", cols, jsValues(method), params)
+  sprintf("DTWidget.formatDate(data, %s%s);", jsValues(method), params)
 }
 
 DateMethods = c(

--- a/R/format.R
+++ b/R/format.R
@@ -6,9 +6,11 @@ formatColumns = function(table, columns, template, ..., appendTo = c('columnDefs
   appendTo = match.arg(appendTo)
   if (appendTo == 'columnDefs') {
     x$options$columnDefs = append(
+      # must append to the front so that the later formatting
+      # can override the previous formatting
       x$options$columnDefs, colFormatter(
         columns, colnames, rownames, template, ...
-      )
+      ), after = 0L
     )
   } else {
     x$options$rowCallback = appendFormatter(

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -17,44 +17,41 @@ var markInterval = function(d, digits, interval, mark, decMark, precision) {
   return xv.join(decMark);
 };
 
-DTWidget.formatCurrency = function(thiz, row, data, col, currency, digits, interval, mark, decMark, before) {
-  var d = parseFloat(data[col]);
+DTWidget.formatCurrency = function(data, currency, digits, interval, mark, decMark, before) {
+  var d = parseFloat(data);
   if (isNaN(d)) return;
   var res = markInterval(d, digits, interval, mark, decMark);
   res = before ? (/^-/.test(res) ? '-' + currency + res.replace(/^-/, '') : currency + res) :
     res + currency;
-  $(thiz.api().cell(row, col).node()).html(res);
+  return res;
 };
 
-DTWidget.formatString = function(thiz, row, data, col, prefix, suffix) {
-  var d = data[col];
+DTWidget.formatString = function(data, prefix, suffix) {
+  var d = data;
   if (d === null) return;
-  var cell = $(thiz.api().cell(row, col).node());
-  cell.html(prefix + cell.html() + suffix);
+  return prefix + cell.html() + suffix;
 };
 
-DTWidget.formatPercentage = function(thiz, row, data, col, digits, interval, mark, decMark) {
-  var d = parseFloat(data[col]);
+DTWidget.formatPercentage = function(data, digits, interval, mark, decMark) {
+  var d = parseFloat(data);
   if (isNaN(d)) return;
-  $(thiz.api().cell(row, col).node())
-  .html(markInterval(d * 100, digits, interval, mark, decMark) + '%');
+  return markInterval(d * 100, digits, interval, mark, decMark) + '%';
 };
 
-DTWidget.formatRound = function(thiz, row, data, col, digits, interval, mark, decMark) {
-  var d = parseFloat(data[col]);
+DTWidget.formatRound = function(data, digits, interval, mark, decMark) {
+  var d = parseFloat(data);
   if (isNaN(d)) return;
-  $(thiz.api().cell(row, col).node()).html(markInterval(d, digits, interval, mark, decMark));
+  return markInterval(d, digits, interval, mark, decMark);
 };
 
-DTWidget.formatSignif = function(thiz, row, data, col, digits, interval, mark, decMark) {
-  var d = parseFloat(data[col]);
+DTWidget.formatSignif = function(data, digits, interval, mark, decMark) {
+  var d = parseFloat(data);
   if (isNaN(d)) return;
-  $(thiz.api().cell(row, col).node())
-    .html(markInterval(d, digits, interval, mark, decMark, true));
+  return markInterval(d, digits, interval, mark, decMark, true);
 };
 
-DTWidget.formatDate = function(thiz, row, data, col, method, params) {
-  var d = data[col];
+DTWidget.formatDate = function(data, method, params) {
+  var d = data;
   if (d === null) return;
   // (new Date('2015-10-28')).toDateString() may return 2015-10-27 because the
   // actual time created could be like 'Tue Oct 27 2015 19:00:00 GMT-0500 (CDT)',
@@ -65,7 +62,7 @@ DTWidget.formatDate = function(thiz, row, data, col, method, params) {
   } else {
     d = new Date(d);
   }
-  $(thiz.api().cell(row, col).node()).html(d[method].apply(d, params));
+  return d[method].apply(d, params);
 };
 
 window.DTWidget = DTWidget;

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -29,7 +29,7 @@ DTWidget.formatCurrency = function(data, currency, digits, interval, mark, decMa
 DTWidget.formatString = function(data, prefix, suffix) {
   var d = data;
   if (d === null) return;
-  return prefix + cell.html() + suffix;
+  return prefix + d + suffix;
 };
 
 DTWidget.formatPercentage = function(data, digits, interval, mark, decMark) {


### PR DESCRIPTION
Closes #776 

Except `formatStyle()`, all other formatting functions now call [column.render](https://datatables.net/reference/option/columns.render) option. By this way, other extensions (like the "Responsive" plugin) can be natively supported. 

The reason that `formatStyle()` still has to use `rowCallback` is it may use other columns' value and it changes the CSS style of the cell. Both seem not possible in `column.render`.

(**UPDATE** Using other values in the same row seems possible but changing the CSS style still not)
(**UPDATE2** It's also possible by hacking to change the CSS style but it still won't work for Responsive Plugin. So I'd rather keep the way it is. See https://github.com/rstudio/DT/issues/399#issuecomment-596184504)

### Example Code 1 (Responsive Plugin now displays all the formatting correctly)

```r
library(DT)
set.seed(100)
x = round(rnorm(10), 2L)
tbl = data.frame(
  A = x,
  B = x,
  C = x,
  D = x,
  E = x * 1e6,
  F = as.Date('2000-01-01') + 0:9,
  G = x
)
x = datatable(tbl, extensions = c('Responsive'), width = '80%', height = '600px',
                       options = list(scrollX = TRUE)) %>% 
  formatPercentage(c('A', 'G')) %>% 
  formatCurrency('B') %>% 
  formatRound('C') %>% 
  formatString('D', "PRE", "SUF") %>%
  formatSignif('E') %>%
  formatDate('F', method = 'toLocaleDateString')
x
```

<img width="353" alt="image" src="https://user-images.githubusercontent.com/8368933/76159434-5e494600-615b-11ea-81b1-fbfa777ec33e.png">


### Example 2 (The override behavior keeps)

```r
# tbl is the same as above
datatable(tbl) %>% formatPercentage(c("A", "B")) %>% formatCurrency("A")
```

<img width="614" alt="image" src="https://user-images.githubusercontent.com/8368933/76159462-9e102d80-615b-11ea-88fa-19ac089e07dc.png">


### Example 3 (The `formatStyle()` still work)

```r
datatable(iris) %>%
  formatStyle('Sepal.Length', fontWeight = styleInterval(5, c('bold', 'weight'))) %>%
  formatStyle('Sepal.Width',
    color = styleInterval(3.4, c('red', 'white')),
    backgroundColor = styleInterval(3.4, c('yellow', 'gray'))
  )
```

<img width="574" alt="image" src="https://user-images.githubusercontent.com/8368933/76159560-e8de7500-615c-11ea-90a9-a4f27e691c79.png">


