### PR TITLE
renderDT() should react to `...` arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.12.2
+Version: 0.12.3
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fix a bug that on Windows, rmarkdown can't render a file that contains DT with PDF download button enabled (thanks, @mfherman @shrektan, #774)
 
+- Fix a bug that `renderDT()` doesn't react to `...` arguments (thanks, @AlfTang @shrektan, #152).
+
 # CHANGES IN DT VERSION 0.12
 
 ## NEW FEATURES

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -77,6 +77,7 @@ renderDataTable = function(
   outputInfoEnv[["session"]] = NULL
 
   exprFunc = shiny::exprToFunction(expr, env, quoted = TRUE)
+  argFunc = shiny::exprToFunction(list(...), env, quoted = FALSE)
   widgetFunc = function() {
     opts = options(DT.datatable.shiny = TRUE); on.exit(options(opts), add = TRUE)
     instance = exprFunc()
@@ -88,8 +89,8 @@ renderDataTable = function(
   }
   processWidget = function(instance) {
     if (!all(c('datatables', 'htmlwidget') %in% class(instance))) {
-      instance = datatable(instance, ...)
-    } else if (length(list(...)) != 0) {
+      instance = do.call(datatable, c(list(instance), argFunc()))
+    } else if (length(argFunc()) != 0) {
       warning("renderDataTable ignores ... arguments when expr yields a datatable object; see ?renderDataTable")
     }
 


### PR DESCRIPTION
Closes #152 

### Before the PR

The left table doesn't react to the select input but the right table does.

### After the PR

Both two tables react the select input.

```r
library(shiny)
library(DT)
ui = fluidPage(
  selectInput('length', "PageLength", c(1:10) * 10),
  fluidRow(
    column(width = 6L, DT::DTOutput('tbl1')),
    column(width = 6L, DT::DTOutput('tbl2'))
  )
)
server = function(input, output) {
  output$tbl1 = DT::renderDT(iris, options = list(pageLength = input$length))
  output$tbl2 = DT::renderDT(DT::datatable(iris, options = list(pageLength = input$length)))
}
shiny::runApp(list(ui = ui, server = server))
```