### PR TITLE
formatting functions allow non-existing columns to be specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Fix a bug that on Windows, rmarkdown can't render a file that contains DT with PDF download button enabled (thanks, @mfherman @shrektan, #774)
 
+## NEW FEATURES
+
+- The formatting function will no longer throw errors for non-existing columns (thanks, @philibe @shrektan, #623).
+
 # CHANGES IN DT VERSION 0.12
 
 ## NEW FEATURES

--- a/R/format.R
+++ b/R/format.R
@@ -153,17 +153,21 @@ formatStyle = function(
 }
 
 # turn character/logical indices to numeric indices
-name2int = function(name, names, rownames) {
+name2int = function(name, names, rownames, noerror = FALSE) {
   if (is.numeric(name)) {
     i = if (all(name >= 0)) name else seq_along(names)[name]
     if (!rownames) i = i - 1
     return(i)
   }
   i = unname(setNames(seq_along(names), names)[name]) - 1
-  if (any(is.na(i))) stop(
-    'You specified the columns: ', paste(name, collapse = ', '), ', ',
-    'but the column names of the data are ', paste(names, collapse = ', ')
-  )
+  if (any(is.na(i))) {
+    if (noerror)
+      i = na.omit(i)
+    else stop(
+      'You specified the columns: ', paste(name, collapse = ', '), ', ',
+      'but the column names of the data are ', paste(names, collapse = ', ')
+    )
+  }
   i
 }
 
@@ -171,7 +175,7 @@ appendFormatter = function(js, name, names, rownames = TRUE, template, ...) {
   js = if (length(js) == 0) c('function(row, data) {', '}') else {
     unlist(strsplit(as.character(js), '\n'))
   }
-  i = name2int(name, names, rownames)
+  i = name2int(name, names, rownames, noerror = TRUE)
   JS(append(
     js, after = length(js) - 1,
     template(i, ..., names, rownames)

--- a/R/format.R
+++ b/R/format.R
@@ -173,12 +173,11 @@ name2int = function(name, names, rownames, noerror = FALSE) {
   }
   i = unname(setNames(seq_along(names), names)[name]) - 1
   if (any(is.na(i))) {
-    if (noerror)
-      i = na.omit(i)
-    else stop(
+    if (!noerror) stop(
       'You specified the columns: ', paste(name, collapse = ', '), ', ',
       'but the column names of the data are ', paste(names, collapse = ', ')
     )
+    i = na.omit(i)
   }
   i
 }


### PR DESCRIPTION
Closes #623 

As discussed in #623, throwing errors when there're non-existing columns may not benefit much:

- If the non-existing column is not desired, the user will notice the error anyway;
- If it's desired, the user will be grateful if we just omit those columns as they are often generated in a dynamic way. Otherwise, the user has to write a verbose code to do that, considering there may be multiple chained formatting functions.


```r
library(DT)
dat = data.frame(A = 1:10, B = 1:10 / 10)
# now fine before fails
datatable(dat) %>% formatPercentage(c("B", "C"))
# now fine before fails
datatable(dat) %>% formatStyle(c("B", "C"), "B", color = "red")
# expect errors as the value column must exist (both before and now)
datatable(dat) %>% formatStyle(c("B", "C"), "C", color = "red")
```