### PR TITLE
DTWidget.formatxxx should return the empty string

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.12.3
+Version: 0.12.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 ## NEW FEATURES
 
-- All the formatting functions except `formatStyle()` now support the `Responsive` plugin (thanks, @shrektan, #777)
+- All the formatting functions except `formatStyle()` now support the `Responsive` plugin (thanks, @andirey @shrektan, #776 #777 #782)
 
 # CHANGES IN DT VERSION 0.12
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -19,7 +19,7 @@ var markInterval = function(d, digits, interval, mark, decMark, precision) {
 
 DTWidget.formatCurrency = function(data, currency, digits, interval, mark, decMark, before) {
   var d = parseFloat(data);
-  if (isNaN(d)) return;
+  if (isNaN(d)) return '';
   var res = markInterval(d, digits, interval, mark, decMark);
   res = before ? (/^-/.test(res) ? '-' + currency + res.replace(/^-/, '') : currency + res) :
     res + currency;
@@ -28,31 +28,31 @@ DTWidget.formatCurrency = function(data, currency, digits, interval, mark, decMa
 
 DTWidget.formatString = function(data, prefix, suffix) {
   var d = data;
-  if (d === null) return;
+  if (d === null) return '';
   return prefix + d + suffix;
 };
 
 DTWidget.formatPercentage = function(data, digits, interval, mark, decMark) {
   var d = parseFloat(data);
-  if (isNaN(d)) return;
+  if (isNaN(d)) return '';
   return markInterval(d * 100, digits, interval, mark, decMark) + '%';
 };
 
 DTWidget.formatRound = function(data, digits, interval, mark, decMark) {
   var d = parseFloat(data);
-  if (isNaN(d)) return;
+  if (isNaN(d)) return '';
   return markInterval(d, digits, interval, mark, decMark);
 };
 
 DTWidget.formatSignif = function(data, digits, interval, mark, decMark) {
   var d = parseFloat(data);
-  if (isNaN(d)) return;
+  if (isNaN(d)) return '';
   return markInterval(d, digits, interval, mark, decMark, true);
 };
 
 DTWidget.formatDate = function(data, method, params) {
   var d = data;
-  if (d === null) return;
+  if (d === null) return '';
   // (new Date('2015-10-28')).toDateString() may return 2015-10-27 because the
   // actual time created could be like 'Tue Oct 27 2015 19:00:00 GMT-0500 (CDT)',
   // i.e. the date-only string is treated as UTC time instead of local time


### PR DESCRIPTION
Fixes #776 

Otherwise, the browser will display a warning box for all the NA elements.

```r
library(DT)
library(dplyr)

# 1. Data set
df_mtcars <- mtcars %>% 
  mutate(
    mpg_percents_visible = mpg / sum(mpg),
    mpg_percents_hidden = mpg / sum(mpg)) %>% 
  select(mpg_percents_visible, mpg_percents_hidden)

# 2. Bug emulation
df_mtcars[2, ]$mpg_percents_hidden <- NA

# 3. Datatable
x <- datatable(df_mtcars) %>% 
  formatPercentage(c('mpg_percents_visible', 'mpg_percents_hidden'))
x
```