### PR TITLE
fix the issue that DT doesn't look right in pkgdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.12.4
+Version: 0.12.5
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - Now DT will always display black text in the RStudio IDE, even under a dark theme like "Cobalt" (thanks, @GegznaV @shrektan, #447 #767).
 
+- Fix the issue that DT doesn't look well in pkgdown (thanks, @jayhesselberth @shrektan, #563).
+
 ## NEW FEATURES
 
 - All the formatting functions except `formatStyle()` now support the `Responsive` plugin (thanks, @andirey @shrektan, #776 #777 #782)

--- a/inst/htmlwidgets/css/datatables-crosstalk.css
+++ b/inst/htmlwidgets/css/datatables-crosstalk.css
@@ -5,3 +5,19 @@
 html body div.DTS div.dataTables_scrollBody {
   background: none;
 }
+
+
+/*
+Fix https://github.com/rstudio/DT/issues/563
+If the `table.display` is set to "block" (e.g., pkgdown), the browser will display
+datatable objects strangely. The search panel and the page buttons will still be
+in full-width but the table body will be "compact" and shorter.
+In therory, having this attributes will affect `dom="t"`
+with `display: block` users. But in reality, there should be no one.
+We may remove the below lines in the future if the upstream agree to have this there.
+See https://github.com/DataTables/DataTablesSrc/issues/160
+*/
+
+table.dataTable {
+  display: table;
+}


### PR DESCRIPTION
Closes #563 

Because [`pkgdown` sets `table {display: block;}` in its CSS file](https://github.com/r-lib/pkgdown/blob/5e873fd9e478dddd784c31d8c8f994fd4b341c2a/inst/assets/pkgdown.css#L197-L200), DT will not be displayed correctly, as it prevents the table body from full-width spanning but not the search panel and the page buttons. 

I proposed this issue in upstream (https://github.com/DataTables/DataTablesSrc/issues/160#issuecomment-602692737) but it may not get fixed there. 

Adding this CSS in their Rmarkdown source file will fix this. However, it usually surprises the user and is difficult to track down the cause.
This fix should be safe in my opinion and considering the large users of both pkgdown and DT, I believe this PR is necessary.

## Example Code

```r
library(shiny)
ui <- fluidPage(
  tags$head(
    tags$style("table {display: block;}")
  ),
  DT::DTOutput('tbl')
)
server <- function(input, output, session) {
  output$tbl <- DT::renderDT({
    iris
  })
}
shiny::runApp(list(ui = ui, server = server))
```

## Before

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/8368933/77340226-f48a8800-6d67-11ea-9284-cf27f1d808b7.png">

## After

<img width="995" alt="image" src="https://user-images.githubusercontent.com/8368933/77340268-02400d80-6d68-11ea-850e-28a8ede70f9f.png">

