### PR TITLE
formatting functions throw clearer error message when 1st arg is not expected

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.13.1
+Version: 0.13.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.14
 
+## MINOR CHANGES
+
+- The formatting functions now throw clearer error messages when called on non-datatables objects (thanks, @shrektan, #785).
 
 # CHANGES IN DT VERSION 0.13
 

--- a/R/format.R
+++ b/R/format.R
@@ -116,6 +116,8 @@ formatSignif = function(
 #'   \code{params = list('ko-KR', list(year = 'numeric', month = 'long', day =
 #'   'numeric'))}
 formatDate = function(table, columns, method = 'toDateString', params = NULL) {
+  if (!inherits(table, 'datatables'))
+    stop("Invalid table argument; a table object created from datatable() was expected")
   x = table$x
   if (x$filter != 'none') {
     if (inherits(columns, 'formula')) columns = all.vars(columns)

--- a/R/format.R
+++ b/R/format.R
@@ -1,4 +1,6 @@
 formatColumns = function(table, columns, template, ..., appendTo = c('columnDefs', 'rowCallback')) {
+  if (!inherits(table, 'datatables'))
+    stop("Invalid table argument; a table object created from datatable() was expected")
   if (inherits(columns, 'formula')) columns = all.vars(columns)
   x = table$x
   colnames = base::attr(x, 'colnames', exact = TRUE)

--- a/tests/testit/test-format.R
+++ b/tests/testit/test-format.R
@@ -6,8 +6,8 @@ assert("formatXXX() should throw clear errors when table is not valid", {
   # So we test both of them
   has_error(formatDate(list(x = 1L)), silent = TRUE)
   has_error(formatCurrency(list(x = 1L)), silent = TRUE)
-  out <- try(formatDate(list(x = 1L)), silent = TRUE)
-  (grepl("Invalid table", attr(out, "condition")$message, fixed = TRUE))
-  out <- try(formatCurrency(list(x = 1L)), silent = TRUE)
-  (grepl("Invalid table", attr(out, "condition")$message, fixed = TRUE))
+  out = try(formatDate(list(x = 1L)), silent = TRUE)
+  (grepl("Invalid table", as.character(out), fixed = TRUE))
+  out = try(formatCurrency(list(x = 1L)), silent = TRUE)
+  (grepl("Invalid table", as.character(out), fixed = TRUE))
 })

--- a/tests/testit/test-format.R
+++ b/tests/testit/test-format.R
@@ -1,0 +1,13 @@
+library(testit)
+
+# fix issue #785
+assert("formatXXX() should throw clear errors when table is not valid", {
+  # The implementation of formatDate is a little different from other formatting functions
+  # So we test both of them
+  has_error(formatDate(list(x = 1L)), silent = TRUE)
+  has_error(formatCurrency(list(x = 1L)), silent = TRUE)
+  out <- try(formatDate(list(x = 1L)), silent = TRUE)
+  (grepl("Invalid table", attr(out, "condition")$message, fixed = TRUE))
+  out <- try(formatCurrency(list(x = 1L)), silent = TRUE)
+  (grepl("Invalid table", attr(out, "condition")$message, fixed = TRUE))
+})


### PR DESCRIPTION
Closes #785 

When the users (usually new beginners) call formatting function on `DT::renderDT()`, incorrectly, the error message thrown is ambiguous, complaining the colnames unmatched.

Now it throws a clearer error message that "a table object created from datatable() was expected".