### PR TITLE
Use the endpoints of the noUiSlider for filtering

### DIFF
--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -516,7 +516,7 @@ HTMLWidgets.widget({
               $x0.hide().trigger('hide');
             },
             input: function() {
-              if ($input.val() === '') filter.val([r1, r2]);
+              if ($input.val() === '') filter.val([filter.noUiSlider('options').range.min, filter.noUiSlider('options').range.max]);
             },
             change: function() {
               var v = $input.val().replace(/\s/g, '');
@@ -526,8 +526,8 @@ HTMLWidgets.widget({
                 $input.parent().addClass('has-error');
                 return;
               }
-              if (v[0] === '') v[0] = r1;
-              if (v[1] === '') v[1] = r2;
+              if (v[0] === '') v[0] = filter.noUiSlider('options').range.min;
+              if (v[1] === '') v[1] = filter.noUiSlider('options').range.max;
               $input.parent().removeClass('has-error');
               // treat date as UTC time at midnight
               var strTime = function(x) {
@@ -543,8 +543,8 @@ HTMLWidgets.widget({
                 v[0] = strTime(v[0]);
                 v[1] = strTime(v[1]);
               }
-              if (v[0] != r1) v[0] *= scale;
-              if (v[1] != r2) v[1] *= scale;
+              if (v[0] != filter.noUiSlider('options').range.min) v[0] *= scale;
+              if (v[1] != filter.noUiSlider('options').range.max) v[1] *= scale;
               filter.val(v);
             }
           });
@@ -598,7 +598,7 @@ HTMLWidgets.widget({
           var updateSlider = function(e) {
             var val = filter.val();
             // turn off filter if in full range
-            $td.data('filter', val[0] > r1 || val[1] < r2);
+            $td.data('filter', val[0] > filter.noUiSlider('options').range.min || val[1] < filter.noUiSlider('options').range.max);
             var v1 = formatDate(val[0]), v2 = formatDate(val[1]), ival;
             if ($td.data('filter')) {
               ival = v1 + ' ... ' + v2;

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -494,6 +494,12 @@ HTMLWidgets.widget({
             // to avoid problems like 3.423/100 -> 0.034230000000000003
             return (x / scale).toFixed(d);
           };
+          var slider_min = function() {
+            return filter.noUiSlider('options').range.min;
+          };
+          var slider_max = function() {
+            return filter.noUiSlider('options').range.max;
+          };
           $input.on({
             focus: function() {
               $x0.show().trigger('show');
@@ -516,7 +522,7 @@ HTMLWidgets.widget({
               $x0.hide().trigger('hide');
             },
             input: function() {
-              if ($input.val() === '') filter.val([filter.noUiSlider('options').range.min, filter.noUiSlider('options').range.max]);
+              if ($input.val() === '') filter.val([slider_min(), slider_max()]);
             },
             change: function() {
               var v = $input.val().replace(/\s/g, '');
@@ -526,8 +532,8 @@ HTMLWidgets.widget({
                 $input.parent().addClass('has-error');
                 return;
               }
-              if (v[0] === '') v[0] = filter.noUiSlider('options').range.min;
-              if (v[1] === '') v[1] = filter.noUiSlider('options').range.max;
+              if (v[0] === '') v[0] = slider_min();
+              if (v[1] === '') v[1] = slider_max();
               $input.parent().removeClass('has-error');
               // treat date as UTC time at midnight
               var strTime = function(x) {
@@ -543,8 +549,8 @@ HTMLWidgets.widget({
                 v[0] = strTime(v[0]);
                 v[1] = strTime(v[1]);
               }
-              if (v[0] != filter.noUiSlider('options').range.min) v[0] *= scale;
-              if (v[1] != filter.noUiSlider('options').range.max) v[1] *= scale;
+              if (v[0] != slider_min()) v[0] *= scale;
+              if (v[1] != slider_max()) v[1] *= scale;
               filter.val(v);
             }
           });
@@ -598,7 +604,7 @@ HTMLWidgets.widget({
           var updateSlider = function(e) {
             var val = filter.val();
             // turn off filter if in full range
-            $td.data('filter', val[0] > filter.noUiSlider('options').range.min || val[1] < filter.noUiSlider('options').range.max);
+            $td.data('filter', val[0] > slider_min() || val[1] < slider_max());
             var v1 = formatDate(val[0]), v2 = formatDate(val[1]), ival;
             if ($td.data('filter')) {
               ival = v1 + ' ... ' + v2;


### PR DESCRIPTION
There is no built in method to update the slider and dropdown filters when data is replaced (#462), however, it is possible for these widgets to be updated using javascript.

In order for the slider to work correctly, the minimum and maximum values of the column need to be based on the endpoints of the slider, instead of hardcoded based on the initial data.