### PR TITLE
Formatting functions should support vectorized arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## BUG FIXES
 
-- Fix the issue that formatting functions don't support vectorized arguments any longer. This was a regression of PR#777 (thanks, @pbreheny @shrektan, #790).
+- Fix the issue that formatting functions don't support vectorized arguments any longer. This was a regression of PR #777 (thanks, @pbreheny @shrektan, #790).
 
 ## MINOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN DT VERSION 0.14
 
+## BUG FIXES
+
+- Fix the issue that formatting functions don't support vectorized arguments any longer. This was a regression of PR#777 (thanks, @pbreheny @shrektan, #790).
+
 ## MINOR CHANGES
 
 - The formatting functions now throw clearer error messages when called on non-datatables objects (thanks, @shrektan, #785).

--- a/R/format.R
+++ b/R/format.R
@@ -41,6 +41,8 @@ formatColumns = function(table, columns, template, ..., appendTo = c('columnDefs
 #' @param before whether to place the currency symbol before or after the values
 #' @references See \url{https://rstudio.github.io/DT/functions.html} for detailed
 #'   documentation and examples.
+#' @note The length of arguments other than \code{table} should be 1 or the same as
+#'   the length of \code{columns}.
 #' @export
 #' @examples # !formatR
 #' library(DT)

--- a/R/format.R
+++ b/R/format.R
@@ -189,7 +189,7 @@ name2int = function(name, names, rownames, noerror = FALSE) {
 colFormatter = function(name, names, rownames = TRUE, template, ...) {
   i = name2int(name, names, rownames)
   js = sprintf("function(data, type, row, meta) { return %s }", template(...))
-  list(list(targets = i, render = JS(js)))
+  Map(function(i, js) list(targets = i, render = JS(js)), i, js)
 }
 
 appendFormatter = function(js, name, names, rownames = TRUE, template, ...) {

--- a/man/formatCurrency.Rd
+++ b/man/formatCurrency.Rd
@@ -128,6 +128,10 @@ number of decimal places (\code{formatRound()}), or a specified number
 of significant figures (\code{formatSignif()}).  The function
 \code{formatStyle()} applies CSS styles to table cells by column.
 }
+\note{
+The length of arguments other than \code{table} should be 1 or the same as
+  the length of \code{columns}.
+}
 \examples{
 library(DT)
 m = cbind(matrix(rnorm(120, 1e5, 1e6), 40), runif(40), rnorm(40, 100))

--- a/tests/testit/test-format.R
+++ b/tests/testit/test-format.R
@@ -11,3 +11,15 @@ assert("formatXXX() should throw clear errors when table is not valid", {
   out = try(formatCurrency(list(x = 1L)), silent = TRUE)
   (grepl("Invalid table", as.character(out), fixed = TRUE))
 })
+
+# fix issue #790
+# should generate the render callback for each columns individually
+assert('formatting functions should support vectorized input', {
+  out = datatable(iris) %>% formatRound(1:2, digits = 1:2)
+  defs = Filter(function(x) !is.null(x$render), out$x$options$columnDefs)
+  (length(defs) %==% 2L)
+  (defs[[1L]]$target %==% 1L)
+  (grepl('DTWidget.formatRound(data, 1, 3', defs[[1L]]$render, fixed = TRUE))
+  (defs[[2L]]$target %==% 2L)
+  (grepl('DTWidget.formatRound(data, 2, 3', defs[[2L]]$render, fixed = TRUE))
+})


### PR DESCRIPTION
Closes #790 
I didn't notice that formatting functions support vectorized inputs when implementing PR #777. This PR fixes my mistakes.

Now the below code works.

```r
library(DT)
dat = data.frame(A = rnorm(1:10), B = rnorm(1:10))
datatable(dat) %>% formatRound(1:2, digits = 3:4)
```

<img width="606" alt="image" src="https://user-images.githubusercontent.com/8368933/78253103-76c43a80-7526-11ea-8c97-291ae5097cc4.png">
