### PR TITLE
Be able to control the Selectable range

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.13.2
+Version: 0.13.3
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN DT VERSION 0.14
 
+## NEW FEATURES
+
+- Now the user is able to control the selection range by `datatable(..., selection = list(selectable = 3:5))`, where positive and negative `selectable` means "enable" and "disable", respectively (thanks, @tomasreigl @shrektan, #201 #793).
+
 ## BUG FIXES
 
 - Fix the issue that formatting functions don't support vectorized arguments any longer. This was a regression of PR #777 (thanks, @pbreheny @shrektan, #790).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- Now the user is able to control the selection range by `datatable(..., selection = list(selectable = 3:5))`, where positive and negative `selectable` means "enable" and "disable", respectively (thanks, @tomasreigl @shrektan, #201 #793).
+- Now the user is able to control the selection range by `datatable(..., selection = list(selectable = 3:5))`, where positive and non-positive `selectable` means "enable" and "disable", respectively (thanks, @tomasreigl @shrektan, #201 #793).
 
 ## BUG FIXES
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -350,6 +350,16 @@ validateSelection = function(x) {
         "- when `target` is 'row+column', `selected` must be in the form of `list(rows = 1, cols = 2)`"
       else if (x$target == 'cell' && !is2ColMatrix(x$selected))
         "- when `target` is 'cell', `selected` must be a 2-col matrix"
+    },
+    selectable = function(x) {
+      if (length(x$selectable) == 0L || is.logical(x$selectable))
+        NULL
+      else if (!sameSign(x$selectable, zero = -1L))
+        "- selectable must be either all positive or all non-positive values"
+      else if (x$target == 'row+column' && !isRowColList(x$selectable))
+        "- when `target` is 'row+column', `selectable` must be in the form of `list(rows = 1, cols = 2)`"
+      else if (x$target == 'cell' && !is2ColMatrix(x$selectable))
+        "- when `target` is 'cell', `selectable` must be a 2-col matrix"
     }
   )
   err = lapply(names(validator), function(e) validator[[e]](x))

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -257,12 +257,15 @@ datatable = function(
       selection = list(mode = match.arg(selection))
     }
     selection = modifyList(
-      list(mode = 'multiple', selected = NULL, target = 'row'), selection
+      list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL), selection
     )
     # for compatibility with DT < 0.1.22 ('selected' could be row names)
     if (grepl('^row', selection$target) && is.character(selection$selected) && length(rn)) {
       selection$selected = match(selection$selected, rn)
     }
+    if (!allPosNeg(selection$selectable))
+      stop('the selectable argument of selection must be NULL or an integer vector ',
+           'with all positive/negative values')
     params$selection = selection
     # warn if the Select ext is used but selection is not set to none
     if ('Select' %in% extensions && selection$mode != 'none') warning(

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -436,7 +436,7 @@ sameSign = function(x, zero = 0L) {
   if (is.list(x)) return(all(vapply(x, sameSign, TRUE, zero = zero)))
   sign = base::sign(x)
   sign[x == 0L] = base::sign(zero)
-  length(unique(sign)) == 1L
+  length(unique(as.vector(sign))) == 1L
 }
 
 #' Generate a table header or footer from column names

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -96,19 +96,19 @@
 #'        and \code{'cell'}.
 #'     \item \code{selected} could be \code{NULL} or indices. The format is specified below.
 #'     \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE} or indices,
-#'       where \code{NULL} and \code{TRUE} means all the table is selectable. When \code{FALSE},
-#'       it means users can't select the table by cursor (but they could still be able to
-#'       select the table via \code{\link{dataTableProxy}}). If indicies, they must be
-#'       all positive or non-positive values. All positive indicies mean only the ranges
-#'       are selectable while all non-positive indicies mean the ranges are \emph{not}
-#'       selectable. The indicies' format is specified below.
+#'       where \code{NULL} and \code{TRUE} mean all the table is selectable. When \code{FALSE},
+#'       it means users can't select the table by the cursor (but they could still be able to
+#'       select the table via \code{\link{dataTableProxy}}). If indices, they must be
+#'       all positive or non-positive values. All positive indices mean only the ranges
+#'       are selectable while all non-positive indices mean the ranges are \emph{not}
+#'       selectable. The indices' format is specified below.
 #'     \item When \code{target} is \code{'row'} or \code{'column'}, \code{selected} and
 #'       \code{selectable} should be a plain numeric vector.
 #'     \item When \code{target} is \code{'row+column'}, \code{selected} and
-#'       \code{selectable} should be provide as a list, specifying \code{rows}
+#'       \code{selectable} should be provided as a list, specifying \code{rows}
 #'       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
 #'     \item When \code{target} is \code{'cell'}, \code{selected} and
-#'       \code{selectable} should be provide as a 2-col \code{matrix}, where the two
+#'       \code{selectable} should be provided as a 2-col \code{matrix}, where the two
 #'       values of each row stand for the row and column indices.
 #'     \item Note that DT has its own selection implementation and doesn't
 #'       use the Select extension because the latter doesn't support the

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -66,7 +66,10 @@
 #'   \code{target} in the list can be \code{'column'} to enable column
 #'   selection, or \code{'row+column'} to make it possible to select both rows
 #'   and columns (click on the footer to select columns), or \code{'cell'} to
-#'   select cells. Note that DT has its own selection implementation and doesn't
+#'   select cells. When \code{target} is \code{'row+column'}, \code{selected}
+#'   should be provide as a list, specifying \code{rows} and \code{cols}
+#'   respectively, e.g., \code{list(rows = 1, cols = 2)}.
+#'   Note that DT has its own selection implementation and doesn't
 #'   use the Select extension because the latter doesn't support the
 #'   server-side processing mode well. Please set this argument to \code{'none'}
 #'   if you really want to use the Select extension.

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -86,18 +86,30 @@
 #'   certain columns.
 #' @details \code{selection}:
 #'   \enumerate{
+#'     \item A scalar string means the selection \code{mode}, whose options are
+#'       \code{'multiple'} (the default), \code{'single'} and \code{'none'}
+#'        (disable selection).
 #'     \item When a list form is provided for this argument, only parts of the
 #'       "full" list are allowed. The default values for non-matched elements are
 #'       \code{list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL)}.
+#'     \item \code{target} must be one of \code{'row'}, \code{'column'}, \code{'row+column'}
+#'        and \code{'cell'}.
+#'     \item \code{selected} could be \code{NULL} or indices. The format is specified below.
+#'     \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE} or indices,
+#'       where \code{NULL} and \code{TRUE} means all the table is selectable. When \code{FALSE},
+#'       it means users can't select the table by cursor (but they could still be able to
+#'       select the table via \code{\link{dataTableProxy}}). If indicies, they must be
+#'       all positive or non-positive values. All positive indicies mean only the ranges
+#'       are selectable while all non-positive indicies mean the ranges are \emph{not}
+#'       selectable. The indicies' format is specified below.
+#'     \item When \code{target} is \code{'row'} or \code{'column'}, \code{selected} and
+#'       \code{selectable} should be a plain numeric vector.
 #'     \item When \code{target} is \code{'row+column'}, \code{selected} and
 #'       \code{selectable} should be provide as a list, specifying \code{rows}
 #'       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
 #'     \item When \code{target} is \code{'cell'}, \code{selected} and
-#'       \code{selectable} should be provide as a 2-col \code{matrix}, where each row
-#'       stands for the row and column indices.
-#'     \item \code{selectable} must be all positive or negative values.
-#'       If the values are all positive, it means only certain rows/columns
-#'       are selectable. Otherwise, it means they are \emph{not} selectable.
+#'       \code{selectable} should be provide as a 2-col \code{matrix}, where the two
+#'       values of each row stand for the row and column indices.
 #'     \item Note that DT has its own selection implementation and doesn't
 #'       use the Select extension because the latter doesn't support the
 #'       server-side processing mode well. Please set this argument to

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -420,10 +420,12 @@ escapeToConfig = function(escape, colnames) {
   sprintf('"%s"', paste(escape, collapse = ','))
 }
 
-allPosNeg = function(x) {
+sameSign = function(x, zero = 0L) {
   if (length(x) == 0L) return(TRUE)
-  if (is.list(x)) return(all(vapply(x, allPosNeg, TRUE)))
-  all(x > 0L) || all(x < 0L)
+  if (is.list(x)) return(all(vapply(x, sameSign, TRUE, zero = zero)))
+  sign = base::sign(x)
+  sign[x == 0L] = base::sign(zero)
+  length(unique(sign)) == 1L
 }
 
 #' Generate a table header or footer from column names

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -62,7 +62,8 @@
 #' @param selection the row/column selection mode (single or multiple selection
 #'   or disable selection) when a table widget is rendered in a Shiny app;
 #'   alternatively, you can use a list of the form \code{list(mode = 'multiple',
-#'   selected = c(1, 3, 8), target = 'row')} to pre-select rows; the element
+#'   selected = c(1, 3, 8), target = 'row', selectable = c(-2, -3))} to
+#'   pre-select rows and control the selectable range; the element
 #'   \code{target} in the list can be \code{'column'} to enable column
 #'   selection, or \code{'row+column'} to make it possible to select both rows
 #'   and columns (click on the footer to select columns), or \code{'cell'} to

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -389,6 +389,12 @@ escapeToConfig = function(escape, colnames) {
   sprintf('"%s"', paste(escape, collapse = ','))
 }
 
+allPosNeg = function(x) {
+  if (length(x) == 0L) return(TRUE)
+  if (is.list(x)) return(all(vapply(x, allPosNeg, TRUE)))
+  all(x > 0L) || all(x < 0L)
+}
+
 #' Generate a table header or footer from column names
 #'
 #' Convenience functions to generate a table header (\samp{<thead></thead>}) or

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -92,11 +92,12 @@
 #'     \item When \code{target} is \code{'row+column'}, \code{selected} and
 #'       \code{selectable} should be provide as a list, specifying \code{rows}
 #'       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
-#'     \item \code{selectable} must be \code{NULL} or an integer vector with
-#'       all positive or negative values. The values are the row or column
-#'       indices of the table. If the values are all positive, it means only
-#'       certain rows/columns are selectable. Otherwise, it means they are
-#'       \emph{not} selectable.
+#'     \item When \code{target} is \code{'cell'}, \code{selected} and
+#'       \code{selectable} should be provide as a 2-col \code{matrix}, where each row
+#'       stands for the row and column indices.
+#'     \item \code{selectable} must be all positive or negative values.
+#'       If the values are all positive, it means only certain rows/columns
+#'       are selectable. Otherwise, it means they are \emph{not} selectable.
 #'     \item Note that DT has its own selection implementation and doesn't
 #'       use the Select extension because the latter doesn't support the
 #'       server-side processing mode well. Please set this argument to

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -86,30 +86,32 @@
 #'   certain columns.
 #' @details \code{selection}:
 #'   \enumerate{
-#'     \item A scalar string means the selection \code{mode}, whose options are
-#'       \code{'multiple'} (the default), \code{'single'} and \code{'none'}
-#'        (disable selection).
+#'     \item The argument could be a scalar string, which means the selection
+#'       \code{mode}, whose value could be one of  \code{'multiple'} (the default),
+#'       \code{'single'} and \code{'none'} (disable selection).
 #'     \item When a list form is provided for this argument, only parts of the
 #'       "full" list are allowed. The default values for non-matched elements are
-#'       \code{list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL)}.
-#'     \item \code{target} must be one of \code{'row'}, \code{'column'}, \code{'row+column'}
-#'        and \code{'cell'}.
-#'     \item \code{selected} could be \code{NULL} or indices. The format is specified below.
-#'     \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE} or indices,
-#'       where \code{NULL} and \code{TRUE} mean all the table is selectable. When \code{FALSE},
-#'       it means users can't select the table by the cursor (but they could still be able to
-#'       select the table via \code{\link{dataTableProxy}}). If indices, they must be
-#'       all positive or non-positive values. All positive indices mean only the ranges
-#'       are selectable while all non-positive indices mean the ranges are \emph{not}
-#'       selectable. The indices' format is specified below.
-#'     \item When \code{target} is \code{'row'} or \code{'column'}, \code{selected} and
-#'       \code{selectable} should be a plain numeric vector.
-#'     \item When \code{target} is \code{'row+column'}, \code{selected} and
-#'       \code{selectable} should be provided as a list, specifying \code{rows}
-#'       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
-#'     \item When \code{target} is \code{'cell'}, \code{selected} and
-#'       \code{selectable} should be provided as a 2-col \code{matrix}, where the two
-#'       values of each row stand for the row and column indices.
+#'       \code{list(mode = 'multiple', selected = NULL, target = 'row',
+#'       selectable = NULL)}.
+#'     \item \code{target} must be one of \code{'row'}, \code{'column'},
+#'       \code{'row+column'} and \code{'cell'}.
+#'     \item \code{selected} could be \code{NULL} or "indices".
+#'     \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE}
+#'       or "indices", where \code{NULL} and \code{TRUE} mean all the table is
+#'       selectable. When \code{FALSE}, it means users can't select the table
+#'       by the cursor (but they could still be able to select the table via
+#'       \code{\link{dataTableProxy}}, specifying \code{ignore.selectable = TRUE}).
+#'       If "indices", they must be all positive or non-positive values. All
+#'       positive "indices" mean only the specified ranges are selectable while all
+#'       non-positive "indices" mean those ranges are \emph{not} selectable.
+#'       The "indices"' format is specified below.
+#'     \item The "indices"' format of \code{selected} and \code{selectable}:
+#'       when \code{target} is \code{'row'} or \code{'column'}, it should be a plain
+#'       numeric vector; when \code{target} is \code{'row+column'}, it should be a
+#'       list, specifying \code{rows} and \code{cols} respectively, e.g.,
+#'       \code{list(rows = 1, cols = 2)}; when \code{target} is \code{'cell'},
+#'       it should be a 2-col \code{matrix}, where the two values of each row
+#'       stand for the row and column index.
 #'     \item Note that DT has its own selection implementation and doesn't
 #'       use the Select extension because the latter doesn't support the
 #'       server-side processing mode well. Please set this argument to

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -283,7 +283,9 @@ datatable = function(
       selection = list(mode = match.arg(selection))
     }
     selection = modifyList(
-      list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL), selection
+      list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL), selection,
+      keep.null = TRUE # this is necessary otherwise the element may become undefined in JS
+      # instead of the null value
     )
     # for compatibility with DT < 0.1.22 ('selected' could be row names)
     if (grepl('^row', selection$target) && is.character(selection$selected) && length(rn)) {

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -67,13 +67,7 @@
 #'   \code{target} in the list can be \code{'column'} to enable column
 #'   selection, or \code{'row+column'} to make it possible to select both rows
 #'   and columns (click on the footer to select columns), or \code{'cell'} to
-#'   select cells. When \code{target} is \code{'row+column'}, \code{selected}
-#'   should be provide as a list, specifying \code{rows} and \code{cols}
-#'   respectively, e.g., \code{list(rows = 1, cols = 2)}.
-#'   Note that DT has its own selection implementation and doesn't
-#'   use the Select extension because the latter doesn't support the
-#'   server-side processing mode well. Please set this argument to \code{'none'}
-#'   if you really want to use the Select extension.
+#'   select cells. See details section for more info.
 #' @param extensions a character vector of the names of the DataTables
 #'   extensions (\url{https://datatables.net/extensions/index})
 #' @param plugins a character vector of the names of DataTables plug-ins
@@ -90,6 +84,24 @@
 #'   \code{row}, \code{column}, or \code{all}, and \code{INDICES} is an integer
 #'   vector of column indices. Use the list form if you want to disable editing
 #'   certain columns.
+#' @details \code{selection}:
+#'   \enumerate{
+#'     \item When a list form is provided for this argument, only parts of the
+#'       "full" list are allowed. The default values for non-matched elements are
+#'       \code{list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL)}.
+#'     \item When \code{target} is \code{'row+column'}, \code{selected} and
+#'       \code{selectable} should be provide as a list, specifying \code{rows}
+#'       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
+#'     \item \code{selectable} must be \code{NULL} or an integer vector with
+#'       all positive or negative values. The values are the row or column
+#'       indices of the table. If the values are all positive, it means only
+#'       certain rows/columns are selectable. Otherwise, it means they are
+#'       \emph{not} selectable.
+#'     \item Note that DT has its own selection implementation and doesn't
+#'       use the Select extension because the latter doesn't support the
+#'       server-side processing mode well. Please set this argument to
+#'       \code{'none'} if you really want to use the Select extension.
+#'   }
 #' @note You are recommended to escape the table content for security reasons
 #'   (e.g. XSS attacks) when using this function in Shiny or any other dynamic
 #'   web applications.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -266,12 +266,13 @@ dataTableProxy = function(
 #' @param selected an integer vector of row/column indices, or a matrix of two
 #'   columns (row and column indices, respectively) for cell indices; you may
 #'   use \code{NULL} to clear existing selections
-#' @param ignore.selectable when \code{TRUE} (the default), the "selectable"
-#'   range that's specified by \code{selection = list(selectable= )} will be
-#'   ignored; otherwise, you can't select the "non-selectable" range.
+#' @param ignore.selectable when \code{FALSE} (the default), the "non-selectable"
+#'   range specified by \code{selection = list(selectable= )} is respected, i.e.,
+#'   you can't select "non-selectable" range. Otherwise, it is ignored.
+#'
 #' @rdname proxy
 #' @export
-selectRows = function(proxy, selected, ignore.selectable = TRUE) {
+selectRows = function(proxy, selected, ignore.selectable = FALSE) {
   invokeRemote(
     proxy, 'selectRows',
     list(I_null(as.integer(selected)), ignore.selectable)
@@ -280,7 +281,7 @@ selectRows = function(proxy, selected, ignore.selectable = TRUE) {
 
 #' @rdname proxy
 #' @export
-selectColumns = function(proxy, selected, ignore.selectable = TRUE) {
+selectColumns = function(proxy, selected, ignore.selectable = FALSE) {
   invokeRemote(
     proxy, 'selectColumns',
     list(I_null(as.integer(selected)), ignore.selectable)
@@ -291,7 +292,7 @@ I_null = function(x) if (is.null(x)) list() else x
 
 #' @rdname proxy
 #' @export
-selectCells = function(proxy, selected, ignore.selectable = TRUE) {
+selectCells = function(proxy, selected, ignore.selectable = FALSE) {
   invokeRemote(
     proxy, 'selectCells',
     list(selected, ignore.selectable)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -268,22 +268,31 @@ dataTableProxy = function(
 #'   use \code{NULL} to clear existing selections
 #' @rdname proxy
 #' @export
-selectRows = function(proxy, selected) {
-  invokeRemote(proxy, 'selectRows', list(I_null(as.integer(selected))))
+selectRows = function(proxy, selected, ignore.selectable = TRUE) {
+  invokeRemote(
+    proxy, 'selectRows',
+    list(I_null(as.integer(selected)), ignore.selectable)
+  )
 }
 
 #' @rdname proxy
 #' @export
-selectColumns = function(proxy, selected) {
-  invokeRemote(proxy, 'selectColumns', list(I_null(as.integer(selected))))
+selectColumns = function(proxy, selected, ignore.selectable = TRUE) {
+  invokeRemote(
+    proxy, 'selectColumns',
+    list(I_null(as.integer(selected)), ignore.selectable)
+  )
 }
 
 I_null = function(x) if (is.null(x)) list() else x
 
 #' @rdname proxy
 #' @export
-selectCells = function(proxy, selected) {
-  invokeRemote(proxy, 'selectCells', list(selected))
+selectCells = function(proxy, selected, ignore.selectable = TRUE) {
+  invokeRemote(
+    proxy, 'selectCells',
+    list(selected, ignore.selectable)
+  )
 }
 
 #' @param data a single row of data to be added to the table; it can be a matrix

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -266,6 +266,9 @@ dataTableProxy = function(
 #' @param selected an integer vector of row/column indices, or a matrix of two
 #'   columns (row and column indices, respectively) for cell indices; you may
 #'   use \code{NULL} to clear existing selections
+#' @param ignore.selectable when \code{TRUE} (the default), the "selectable"
+#'   range that's specified by \code{selection = list(selectable= )} will be
+#'   ignored; otherwise, you can't select the "non-selectable" range.
 #' @rdname proxy
 #' @export
 selectRows = function(proxy, selected, ignore.selectable = TRUE) {

--- a/inst/examples/DT-selection/server.R
+++ b/inst/examples/DT-selection/server.R
@@ -20,12 +20,12 @@ shinyServer(function(input, output, session) {
   output$y14 = renderPrint(input$x14_rows_selected)
 
   output$x15 = DT::renderDataTable(
-    df, server = FALSE, selection = list(selected = c(1, 3, 4, 6, 9))
+    df, server = FALSE, selection = list(selected = c(1, 3, 4, 6, 9), selectable = -(3:5))
   )
   output$y15 = renderPrint(input$x15_rows_selected)
 
   output$x16 = DT::renderDataTable(
-    df, selection = list(selected = c(1, 3, 4, 6, 9))
+    df, selection = list(selected = c(1, 3, 4, 6, 9), selectable = -(3:5))
   )
   output$y16 = renderPrint(input$x16_rows_selected)
 
@@ -49,12 +49,12 @@ shinyServer(function(input, output, session) {
   output$y24 = renderPrint(input$x24_columns_selected)
 
   output$x25 = DT::renderDataTable(
-    df, server = FALSE, selection = list(target = 'column', selected = c(1, 3))
+    df, server = FALSE, selection = list(target = 'column', selected = c(1, 3, 6), selectable = -(3:5))
   )
   output$y25 = renderPrint(input$x25_columns_selected)
 
   output$x26 = DT::renderDataTable(
-    df, selection = list(target = 'column', selected = c(1, 3))
+    df, selection = list(target = 'column', selected = c(1, 3, 6))
   )
   output$y26 = renderPrint(input$x26_columns_selected)
 
@@ -82,7 +82,7 @@ shinyServer(function(input, output, session) {
     server = FALSE,
     selection = list(target = 'cell', selected = cbind(
       c(1, 3, 4, 9), c(3, 2, 1, 2)
-    ))
+    ), selectable = -cbind(1:5, 1))
   )
   output$y35 = renderPrint(input$x35_cells_selected)
 
@@ -90,7 +90,7 @@ shinyServer(function(input, output, session) {
     df,
     selection = list(target = 'cell', selected = cbind(
       c(1, 3, 4, 9), c(3, 2, 1, 2)
-    ))
+    ), selectable = -cbind(1:5, 1))
   )
   output$y36 = renderPrint(input$x36_cells_selected)
 
@@ -124,6 +124,8 @@ shinyServer(function(input, output, session) {
     server = FALSE,
     selection = list(target = 'row+column', selected = list(
       rows = c(1, 3, 4, 9), cols = c(3, 2)
+    ), selectable = list(
+      rows = -3, cols = 1:5
     ))
   )
   output$y45 = renderPrint(print_rows_cols('x45'))
@@ -132,6 +134,8 @@ shinyServer(function(input, output, session) {
     df,
     selection = list(target = 'row+column', selected = list(
       rows = c(1, 3, 4, 9), cols = c(3, 2)
+    ), selectable = list(
+      rows = -3, cols = 1:5
     ))
   )
   output$y46 = renderPrint(print_rows_cols('x46'))

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1005,7 +1005,7 @@ HTMLWidgets.widget({
         }
         // Change selected1's value based on selectable1, then
         // refresh the row selection state according to values in selected1
-        var selectRows = function(ignoreSelectable = false) {
+        var selectRows = function(ignoreSelectable) {
           if (!ignoreSelectable) onlyKeepSelectableRows();
           table.$('tr.' + selClass).removeClass(selClass);
           if (selected1.length === 0) return;
@@ -1072,18 +1072,18 @@ HTMLWidgets.widget({
             if (inArray(id, selected1)) selected1.splice($.inArray(id, selected1), 1);
           }
           selectedRows(); // need to call to update selected1 values
-          selectRows(); // only keep the selectable rows
+          selectRows(false); // only keep the selectable rows
           changeInput('rows_selected', selected1);
           changeInput('row_last_clicked', serverRowIndex(thisRow.index()));
           lastClickedRow = serverRowIndex(thisRow.index());
         });
         changeInput('rows_selected', selected1);
-        selectRows();  // in case users have specified pre-selected rows
+        selectRows(false);  // in case users have specified pre-selected rows
         // restore selected rows after the table is redrawn (e.g. sort/search/page);
         // client-side tables will preserve the selections automatically; for
         // server-side tables, we have to *real* row indices are in `selected1`
-        if (server) table.on('draw.dt', selectRows);
-        methods.selectRows = function(selected, ignoreSelectable = true) {
+        if (server) table.on('draw.dt', function(e) { selectRows(false); });
+        methods.selectRows = function(selected, ignoreSelectable) {
           selected1 = $.makeArray(selected);
           selectRows(ignoreSelectable);
           changeInput('rows_selected', selected1);
@@ -1111,7 +1111,7 @@ HTMLWidgets.widget({
         }
         // update selected2 and then
         // refresh the col selection state according to values in selected2
-        var selectCols = function(ignoreSelectable = false) {
+        var selectCols = function(ignoreSelectable) {
           if (!ignoreSelectable) onlyKeepSelectableCols();
           table.columns().nodes().flatten().to$().removeClass(selClass);
           if (selected2.length > 0)
@@ -1130,7 +1130,7 @@ HTMLWidgets.widget({
             thisCol.addClass(selClass);
             selected2 = selMode === 'single' ? [colIdx] : unique(selected2.concat([colIdx]));
           }
-          selectCols(); // update selected2 based on selectable
+          selectCols(false); // update selected2 based on selectable
           changeInput('columns_selected', selected2);
         }
         if (selTarget === 'column') {
@@ -1138,10 +1138,10 @@ HTMLWidgets.widget({
         } else {
           $(table.table().footer()).on('click.dt', 'tr th', callback);
         }
-        selectCols();  // in case users have specified pre-selected columns
+        selectCols(false);  // in case users have specified pre-selected columns
         changeInput('columns_selected', selected2);
-        if (server) table.on('draw.dt', selectCols);
-        methods.selectColumns = function(selected, ignoreSelectable = true) {
+        if (server) table.on('draw.dt', function(e) { selectCols(false); });
+        methods.selectColumns = function(selected, ignoreSelectable) {
           selected2 = $.makeArray(selected);
           selectCols(ignoreSelectable);
           changeInput('columns_selected', selected2);
@@ -1181,7 +1181,7 @@ HTMLWidgets.widget({
         }
         // Change selected3's value based on selectable3, then
         // refresh the cell selection state according to values in selected3
-        var selectCells = function(ignoreSelectable = false) {
+        var selectCells = function(ignoreSelectable) {
           if (!ignoreSelectable) onlyKeepSelectableCells();
           table.$('td.' + selClass).removeClass(selClass);
           if (selected3.length === 0) return;
@@ -1208,14 +1208,14 @@ HTMLWidgets.widget({
             selected3 = selMode === 'single' ? [[info.row, info.col]] :
               unique(selected3.concat([[info.row, info.col]]));
           }
-          selectCells(); // must call this to update selected3 based on selectable3
+          selectCells(false); // must call this to update selected3 based on selectable3
           changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');
         });
-        selectCells();  // in case users have specified pre-selected columns
+        selectCells(false);  // in case users have specified pre-selected columns
         changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');
 
-        if (server) table.on('draw.dt', selectCells);
-        methods.selectCells = function(selected, ignoreSelectable = true) {
+        if (server) table.on('draw.dt', function(e) { selectCells(false); });
+        methods.selectCells = function(selected, ignoreSelectable) {
           selected3 = selected ? selected : [];
           selectCells(ignoreSelectable);
           changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1005,8 +1005,8 @@ HTMLWidgets.widget({
         }
         // Change selected1's value based on selectable1, then
         // refresh the row selection state according to values in selected1
-        var selectRows = function() {
-          onlyKeepSelectableRows();
+        var selectRows = function(ignoreSelectable = false) {
+          if (!ignoreSelectable) onlyKeepSelectableRows();
           table.$('tr.' + selClass).removeClass(selClass);
           if (selected1.length === 0) return;
           if (server) {
@@ -1083,9 +1083,9 @@ HTMLWidgets.widget({
         // client-side tables will preserve the selections automatically; for
         // server-side tables, we have to *real* row indices are in `selected1`
         if (server) table.on('draw.dt', selectRows);
-        methods.selectRows = function(selected) {
+        methods.selectRows = function(selected, ignoreSelectable) {
           selected1 = $.makeArray(selected);
-          selectRows();
+          selectRows(ignoreSelectable);
           changeInput('rows_selected', selected1);
         }
       }
@@ -1111,8 +1111,8 @@ HTMLWidgets.widget({
         }
         // update selected2 and then
         // refresh the col selection state according to values in selected2
-        var selectCols = function() {
-          onlyKeepSelectableCols();
+        var selectCols = function(ignoreSelectable = false) {
+          if (!ignoreSelectable) onlyKeepSelectableCols();
           table.columns().nodes().flatten().to$().removeClass(selClass);
           if (selected2.length > 0)
             table.columns(selected2).nodes().flatten().to$().addClass(selClass);
@@ -1141,9 +1141,9 @@ HTMLWidgets.widget({
         selectCols();  // in case users have specified pre-selected columns
         changeInput('columns_selected', selected2);
         if (server) table.on('draw.dt', selectCols);
-        methods.selectColumns = function(selected) {
+        methods.selectColumns = function(selected, ignoreSelectable) {
           selected2 = $.makeArray(selected);
-          selectCols();
+          selectCols(ignoreSelectable);
           changeInput('columns_selected', selected2);
         }
       }
@@ -1181,8 +1181,8 @@ HTMLWidgets.widget({
         }
         // Change selected3's value based on selectable3, then
         // refresh the cell selection state according to values in selected3
-        var selectCells = function() {
-          onlyKeepSelectableCells();
+        var selectCells = function(ignoreSelectable = false) {
+          if (!ignoreSelectable) onlyKeepSelectableCells();
           table.$('td.' + selClass).removeClass(selClass);
           if (selected3.length === 0) return;
           if (server) {
@@ -1215,9 +1215,9 @@ HTMLWidgets.widget({
         changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');
 
         if (server) table.on('draw.dt', selectCells);
-        methods.selectCells = function(selected) {
+        methods.selectCells = function(selected, ignoreSelectable) {
           selected3 = selected ? selected : [];
-          selectCells();
+          selectCells(ignoreSelectable);
           changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');
         }
       }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -930,18 +930,25 @@ HTMLWidgets.widget({
     var selMode = data.selection.mode, selTarget = data.selection.target;
     if (inArray(selMode, ['single', 'multiple'])) {
       var selClass = inArray(data.style, ['bootstrap', 'bootstrap4']) ? 'active' : 'selected';
-      var selected = data.selection.selected, selected1, selected2;
       // selected1: row indices; selected2: column indices
-      if (selected === null) {
-        selected1 = selected2 = [];
-      } else if (selTarget === 'row') {
-        selected1 = $.makeArray(selected);
-      } else if (selTarget === 'column') {
-        selected2 = $.makeArray(selected);
-      } else if (selTarget === 'row+column') {
-        selected1 = $.makeArray(selected.rows);
-        selected2 = $.makeArray(selected.cols);
+      var initSel = function(x) {
+        if (x === null) {
+          return {rows: [], cols: []};
+        } else if (selTarget === 'row') {
+          return {rows: $.makeArray(x), cols: []};
+        } else if (selTarget === 'column') {
+          return {rows: [], cols: $.makeArray(x)};
+        } else if (selTarget === 'row+column') {
+          return {rows: $.makeArray(x.rows), cols: $.makeArray(x.cols)};
+        }
       }
+      var selected = data.selection.selected;
+      var selected1 = initSel(selected).rows, selected2 = initSel(selected).cols;
+      // selectable should contain either positive or negative values, not both, not zero
+      // positive values indicate "selectable" while negative values means "nonselectable"
+      // the assertion is performed on R side
+      var selectable = data.selection.selectable;
+      var selectable1 = initSel(selectable).rows, selectable2 = initSel(selectable).cols;
 
       // After users reorder the rows or filter the table, we cannot use the table index
       // directly. Instead, we need this function to find out the rows between the two clicks.

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -986,6 +986,7 @@ HTMLWidgets.widget({
             return DT_rows_current[i];
           });
           selected1 = selMode === 'multiple' ? unique(selected1.concat(idx)) : idx;
+          selected1 = $(selected1).filter(DT_rows_all).get(); // ensure it's valid row index
           return selected1;
         }
         // Change selected1's value based on selectable1, then refresh the row state
@@ -1006,6 +1007,7 @@ HTMLWidgets.widget({
         // Change selected1's value based on selectable1, then
         // refresh the row selection state according to values in selected1
         var selectRows = function(ignoreSelectable) {
+          selectedRows(); // update selected1's value
           if (!ignoreSelectable) onlyKeepSelectableRows();
           table.$('tr.' + selClass).removeClass(selClass);
           if (selected1.length === 0) return;
@@ -1017,6 +1019,10 @@ HTMLWidgets.widget({
             });
           } else {
             var selected0 = selected1.map(function(i) { return i - 1; });
+            // selected0 must be valid row index otherwise this line can't be
+            // executed properly. However, unlike in `selectCols()`, we don't
+            // need to handle this specially, as `selectedRows()` above will
+            // override selected1's value
             $(table.rows(selected0).nodes()).addClass(selClass);
           }
         }
@@ -1071,7 +1077,6 @@ HTMLWidgets.widget({
             // remove id from selected1 since its class .selected has been removed
             if (inArray(id, selected1)) selected1.splice($.inArray(id, selected1), 1);
           }
-          selectedRows(); // need to call to update selected1 values
           selectRows(false); // only keep the selectable rows
           changeInput('rows_selected', selected1);
           changeInput('row_last_clicked', serverRowIndex(thisRow.index()));

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1083,7 +1083,7 @@ HTMLWidgets.widget({
         // client-side tables will preserve the selections automatically; for
         // server-side tables, we have to *real* row indices are in `selected1`
         if (server) table.on('draw.dt', selectRows);
-        methods.selectRows = function(selected, ignoreSelectable) {
+        methods.selectRows = function(selected, ignoreSelectable = true) {
           selected1 = $.makeArray(selected);
           selectRows(ignoreSelectable);
           changeInput('rows_selected', selected1);
@@ -1141,7 +1141,7 @@ HTMLWidgets.widget({
         selectCols();  // in case users have specified pre-selected columns
         changeInput('columns_selected', selected2);
         if (server) table.on('draw.dt', selectCols);
-        methods.selectColumns = function(selected, ignoreSelectable) {
+        methods.selectColumns = function(selected, ignoreSelectable = true) {
           selected2 = $.makeArray(selected);
           selectCols(ignoreSelectable);
           changeInput('columns_selected', selected2);
@@ -1215,7 +1215,7 @@ HTMLWidgets.widget({
         changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');
 
         if (server) table.on('draw.dt', selectCells);
-        methods.selectCells = function(selected, ignoreSelectable) {
+        methods.selectCells = function(selected, ignoreSelectable = true) {
           selected3 = selected ? selected : [];
           selectCells(ignoreSelectable);
           changeInput('cells_selected', transposeArray2D(selected3), 'shiny.matrix');

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -168,10 +168,6 @@ HTMLWidgets.widget({
     if (!data.selection) data.selection = {
       mode: 'none', selected: null, target: 'row', selectable: null
     };
-    // htmlwidgets may removed the null data
-    if (data.selection.selected === undefined) data.selection.selected = null;
-    if (data.selection.selectable === undefined) data.selection.selectable = null;
-
     if (HTMLWidgets.shinyMode && data.selection.mode !== 'none' &&
         data.selection.target === 'row+column') {
       if ($table.children('tfoot').length === 0) {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -166,7 +166,7 @@ HTMLWidgets.widget({
     if (data.caption) $table.prepend(data.caption);
 
     if (!data.selection) data.selection = {
-      mode: 'none', selected: null, target: 'row'
+      mode: 'none', selected: null, target: 'row', selectable: null
     };
     if (HTMLWidgets.shinyMode && data.selection.mode !== 'none' &&
         data.selection.target === 'row+column') {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -945,8 +945,8 @@ HTMLWidgets.widget({
       }
       var selected = data.selection.selected;
       var selected1 = initSel(selected).rows, selected2 = initSel(selected).cols;
-      // selectable should contain either positive or negative values, not both
-      // positive values indicate "selectable" while negative and zero values means "nonselectable"
+      // selectable should contain either all positive or all non-positive values, not both
+      // positive values indicate "selectable" while non-positive values means "nonselectable"
       // the assertion is performed on R side. (only column indicides could be zero which indicates
       // the row name)
       var selectable = data.selection.selectable;

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1113,6 +1113,9 @@ HTMLWidgets.widget({
         // refresh the col selection state according to values in selected2
         var selectCols = function(ignoreSelectable) {
           if (!ignoreSelectable) onlyKeepSelectableCols();
+          // if selected2 is not a valide index (e.g., larger than the column number)
+          // table.columns(selected2) will fail and result in a blank table
+          selected2 = $(selected2).filter(table.columns().indexes()).get();
           table.columns().nodes().flatten().to$().removeClass(selClass);
           if (selected2.length > 0)
             table.columns(selected2).nodes().flatten().to$().addClass(selClass);

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -944,9 +944,10 @@ HTMLWidgets.widget({
       }
       var selected = data.selection.selected;
       var selected1 = initSel(selected).rows, selected2 = initSel(selected).cols;
-      // selectable should contain either positive or negative values, not both, not zero
-      // positive values indicate "selectable" while negative values means "nonselectable"
-      // the assertion is performed on R side
+      // selectable should contain either positive or negative values, not both
+      // positive values indicate "selectable" while negative and zero values means "nonselectable"
+      // the assertion is performed on R side. (only column indicides could be zero which indicates
+      // the row name)
       var selectable = data.selection.selectable;
       var selectable1 = initSel(selectable).rows, selectable2 = initSel(selectable).cols;
 
@@ -989,7 +990,7 @@ HTMLWidgets.widget({
         // Change selected1's value based on selectable1, then refresh the row state
         var onlyKeepSelectableRows = function() {
           if (selectable1.length === 0) return;
-          var nonselectable = selectable1[0] < 0;
+          var nonselectable = selectable1[0] <= 0;
           if (nonselectable) {
             // should make selectable1 positive
             selected1 = $(selected1).not(selectable1.map(function(i) { return -i; })).get();
@@ -1091,7 +1092,7 @@ HTMLWidgets.widget({
         // update selected2's value based on selectable2
         var onlyKeepSelectableCols = function() {
           if (selectable2.length === 0) return;
-          var nonselectable = selectable2[0] < 0;
+          var nonselectable = selectable2[0] <= 0;
           if (nonselectable) {
             // need to make selectable2 positive
             selected2 = $(selected2).not(selectable2.map(function(i) { return -i; })).get();
@@ -1151,7 +1152,7 @@ HTMLWidgets.widget({
          // Change selected3's value based on selectable3, then refresh the cell state
         var onlyKeepSelectableCells = function() {
           if (selectable3.length === 0) return;
-          var nonselectable = selectable3[0][0] < 0;
+          var nonselectable = selectable3[0][0] <= 0;
           var out = [];
           if (nonselectable) {
             selected3.map(function(ij) {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -928,11 +928,12 @@ HTMLWidgets.widget({
     }
 
     var selMode = data.selection.mode, selTarget = data.selection.target;
+    var selDisable = data.selection.selectable === false;
     if (inArray(selMode, ['single', 'multiple'])) {
       var selClass = inArray(data.style, ['bootstrap', 'bootstrap4']) ? 'active' : 'selected';
       // selected1: row indices; selected2: column indices
       var initSel = function(x) {
-        if (x === null || selTarget === 'cell') {
+        if (x === null || typeof x === 'boolean' || selTarget === 'cell') {
           return {rows: [], cols: []};
         } else if (selTarget === 'row') {
           return {rows: $.makeArray(x), cols: []};
@@ -989,6 +990,10 @@ HTMLWidgets.widget({
         }
         // Change selected1's value based on selectable1, then refresh the row state
         var onlyKeepSelectableRows = function() {
+          if (selDisable) { // users can't select; useful when only want backend select
+            selected1 = [];
+            return;
+          }
           if (selectable1.length === 0) return;
           var nonselectable = selectable1[0] <= 0;
           if (nonselectable) {
@@ -1091,6 +1096,10 @@ HTMLWidgets.widget({
         }
         // update selected2's value based on selectable2
         var onlyKeepSelectableCols = function() {
+          if (selDisable) { // users can't select; useful when only want backend select
+            selected2 = [];
+            return;
+          }
           if (selectable2.length === 0) return;
           var nonselectable = selectable2[0] <= 0;
           if (nonselectable) {
@@ -1142,7 +1151,7 @@ HTMLWidgets.widget({
       if (selTarget === 'cell') {
         var selected3 = [], selectable3 = [];
         if (selected !== null) selected3 = selected;
-        if (selectable !== null) selectable3 = selectable;
+        if (selectable !== null && typeof selectable !== 'boolean') selectable3 = selectable;
         var findIndex = function(ij, sel) {
           for (var i = 0; i < sel.length; i++) {
             if (ij[0] === sel[i][0] && ij[1] === sel[i][1]) return i;
@@ -1151,6 +1160,10 @@ HTMLWidgets.widget({
         }
          // Change selected3's value based on selectable3, then refresh the cell state
         var onlyKeepSelectableCells = function() {
+          if (selDisable) { // users can't select; useful when only want backend select
+            selected3 = [];
+            return;
+          }
           if (selectable3.length === 0) return;
           var nonselectable = selectable3[0][0] <= 0;
           var out = [];

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -990,7 +990,6 @@ HTMLWidgets.widget({
             return DT_rows_current[i];
           });
           selected1 = selMode === 'multiple' ? unique(selected1.concat(idx)) : idx;
-          selected1 = $(selected1).filter(DT_rows_all).get(); // ensure it's valid row index
           return selected1;
         }
         // Change selected1's value based on selectable1, then refresh the row state
@@ -1026,7 +1025,7 @@ HTMLWidgets.widget({
             // selected0 must be valid row index otherwise this line can't be
             // executed properly. However, unlike in `selectCols()`, we don't
             // need to handle this specially, as `selectedRows()` above will
-            // override selected1's value
+            // override selected1's value in the client-processing mode
             $(table.rows(selected0).nodes()).addClass(selClass);
           }
         }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -932,7 +932,7 @@ HTMLWidgets.widget({
       var selClass = inArray(data.style, ['bootstrap', 'bootstrap4']) ? 'active' : 'selected';
       // selected1: row indices; selected2: column indices
       var initSel = function(x) {
-        if (x === null) {
+        if (x === null || selTarget === 'cell') {
           return {rows: [], cols: []};
         } else if (selTarget === 'row') {
           return {rows: $.makeArray(x), cols: []};

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1077,11 +1077,11 @@ HTMLWidgets.widget({
           changeInput('row_last_clicked', serverRowIndex(thisRow.index()));
           lastClickedRow = serverRowIndex(thisRow.index());
         });
-        changeInput('rows_selected', selected1);
         selectRows(false);  // in case users have specified pre-selected rows
         // restore selected rows after the table is redrawn (e.g. sort/search/page);
         // client-side tables will preserve the selections automatically; for
         // server-side tables, we have to *real* row indices are in `selected1`
+        changeInput('rows_selected', selected1);
         if (server) table.on('draw.dt', function(e) { selectRows(false); });
         methods.selectRows = function(selected, ignoreSelectable) {
           selected1 = $.makeArray(selected);

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -168,6 +168,10 @@ HTMLWidgets.widget({
     if (!data.selection) data.selection = {
       mode: 'none', selected: null, target: 'row', selectable: null
     };
+    // htmlwidgets may removed the null data
+    if (data.selection.selected === undefined) data.selection.selected = null;
+    if (data.selection.selectable === undefined) data.selection.selectable = null;
+
     if (HTMLWidgets.shinyMode && data.selection.mode !== 'none' &&
         data.selection.target === 'row+column') {
       if ($table.children('tfoot').length === 0) {

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -136,30 +136,32 @@ data frame) using the JavaScript library DataTables.
 \details{
 \code{selection}:
   \enumerate{
-    \item A scalar string means the selection \code{mode}, whose options are
-      \code{'multiple'} (the default), \code{'single'} and \code{'none'}
-       (disable selection).
+    \item The argument could be a scalar string, which means the selection
+      \code{mode}, whose value could be one of  \code{'multiple'} (the default),
+      \code{'single'} and \code{'none'} (disable selection).
     \item When a list form is provided for this argument, only parts of the
       "full" list are allowed. The default values for non-matched elements are
-      \code{list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL)}.
-    \item \code{target} must be one of \code{'row'}, \code{'column'}, \code{'row+column'}
-       and \code{'cell'}.
-    \item \code{selected} could be \code{NULL} or indices. The format is specified below.
-    \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE} or indices,
-      where \code{NULL} and \code{TRUE} mean all the table is selectable. When \code{FALSE},
-      it means users can't select the table by the cursor (but they could still be able to
-      select the table via \code{\link{dataTableProxy}}). If indices, they must be
-      all positive or non-positive values. All positive indices mean only the ranges
-      are selectable while all non-positive indices mean the ranges are \emph{not}
-      selectable. The indices' format is specified below.
-    \item When \code{target} is \code{'row'} or \code{'column'}, \code{selected} and
-      \code{selectable} should be a plain numeric vector.
-    \item When \code{target} is \code{'row+column'}, \code{selected} and
-      \code{selectable} should be provided as a list, specifying \code{rows}
-      and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
-    \item When \code{target} is \code{'cell'}, \code{selected} and
-      \code{selectable} should be provided as a 2-col \code{matrix}, where the two
-      values of each row stand for the row and column indices.
+      \code{list(mode = 'multiple', selected = NULL, target = 'row',
+      selectable = NULL)}.
+    \item \code{target} must be one of \code{'row'}, \code{'column'},
+      \code{'row+column'} and \code{'cell'}.
+    \item \code{selected} could be \code{NULL} or "indices".
+    \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE}
+      or "indices", where \code{NULL} and \code{TRUE} mean all the table is
+      selectable. When \code{FALSE}, it means users can't select the table
+      by the cursor (but they could still be able to select the table via
+      \code{\link{dataTableProxy}}, specifying \code{ignore.selectable = TRUE}).
+      If "indices", they must be all positive or non-positive values. All
+      positive "indices" mean only the specified ranges are selectable while all
+      non-positive "indices" mean those ranges are \emph{not} selectable.
+      The "indices"' format is specified below.
+    \item The "indices"' format of \code{selected} and \code{selectable}:
+      when \code{target} is \code{'row'} or \code{'column'}, it should be a plain
+      numeric vector; when \code{target} is \code{'row+column'}, it should be a
+      list, specifying \code{rows} and \code{cols} respectively, e.g.,
+      \code{list(rows = 1, cols = 2)}; when \code{target} is \code{'cell'},
+      it should be a 2-col \code{matrix}, where the two values of each row
+      stand for the row and column index.
     \item Note that DT has its own selection implementation and doesn't
       use the Select extension because the latter doesn't support the
       server-side processing mode well. Please set this argument to

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -103,7 +103,8 @@ when the number of total records is less than the page size.}
 \item{selection}{the row/column selection mode (single or multiple selection
 or disable selection) when a table widget is rendered in a Shiny app;
 alternatively, you can use a list of the form \code{list(mode = 'multiple',
-selected = c(1, 3, 8), target = 'row')} to pre-select rows; the element
+selected = c(1, 3, 8), target = 'row', selectable = c(-2, -3))} to
+pre-select rows and control the selectable range; the element
 \code{target} in the list can be \code{'column'} to enable column
 selection, or \code{'row+column'} to make it possible to select both rows
 and columns (click on the footer to select columns), or \code{'cell'} to

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -108,13 +108,7 @@ pre-select rows and control the selectable range; the element
 \code{target} in the list can be \code{'column'} to enable column
 selection, or \code{'row+column'} to make it possible to select both rows
 and columns (click on the footer to select columns), or \code{'cell'} to
-select cells. When \code{target} is \code{'row+column'}, \code{selected}
-should be provide as a list, specifying \code{rows} and \code{cols}
-respectively, e.g., \code{list(rows = 1, cols = 2)}.
-Note that DT has its own selection implementation and doesn't
-use the Select extension because the latter doesn't support the
-server-side processing mode well. Please set this argument to \code{'none'}
-if you really want to use the Select extension.}
+select cells. See details section for more info.}
 
 \item{extensions}{a character vector of the names of the DataTables
 extensions (\url{https://datatables.net/extensions/index})}
@@ -138,6 +132,26 @@ certain columns.}
 \description{
 This function creates an HTML widget to display rectangular data (a matrix or
 data frame) using the JavaScript library DataTables.
+}
+\details{
+\code{selection}:
+  \enumerate{
+    \item When a list form is provided for this argument, only parts of the
+      "full" list are allowed. The default values for non-matched elements are
+      \code{list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL)}.
+    \item When \code{target} is \code{'row+column'}, \code{selected} and
+      \code{selectable} should be provide as a list, specifying \code{rows}
+      and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
+    \item \code{selectable} must be \code{NULL} or an integer vector with
+      all positive or negative values. The values are the row or column
+      indices of the table. If the values are all positive, it means only
+      certain rows/columns are selectable. Otherwise, it means they are
+      \emph{not} selectable.
+    \item Note that DT has its own selection implementation and doesn't
+      use the Select extension because the latter doesn't support the
+      server-side processing mode well. Please set this argument to
+      \code{'none'} if you really want to use the Select extension.
+  }
 }
 \note{
 You are recommended to escape the table content for security reasons

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -146,19 +146,19 @@ data frame) using the JavaScript library DataTables.
        and \code{'cell'}.
     \item \code{selected} could be \code{NULL} or indices. The format is specified below.
     \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE} or indices,
-      where \code{NULL} and \code{TRUE} means all the table is selectable. When \code{FALSE},
-      it means users can't select the table by cursor (but they could still be able to
-      select the table via \code{\link{dataTableProxy}}). If indicies, they must be
-      all positive or non-positive values. All positive indicies mean only the ranges
-      are selectable while all non-positive indicies mean the ranges are \emph{not}
-      selectable. The indicies' format is specified below.
+      where \code{NULL} and \code{TRUE} mean all the table is selectable. When \code{FALSE},
+      it means users can't select the table by the cursor (but they could still be able to
+      select the table via \code{\link{dataTableProxy}}). If indices, they must be
+      all positive or non-positive values. All positive indices mean only the ranges
+      are selectable while all non-positive indices mean the ranges are \emph{not}
+      selectable. The indices' format is specified below.
     \item When \code{target} is \code{'row'} or \code{'column'}, \code{selected} and
       \code{selectable} should be a plain numeric vector.
     \item When \code{target} is \code{'row+column'}, \code{selected} and
-      \code{selectable} should be provide as a list, specifying \code{rows}
+      \code{selectable} should be provided as a list, specifying \code{rows}
       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
     \item When \code{target} is \code{'cell'}, \code{selected} and
-      \code{selectable} should be provide as a 2-col \code{matrix}, where the two
+      \code{selectable} should be provided as a 2-col \code{matrix}, where the two
       values of each row stand for the row and column indices.
     \item Note that DT has its own selection implementation and doesn't
       use the Select extension because the latter doesn't support the

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -107,7 +107,10 @@ selected = c(1, 3, 8), target = 'row')} to pre-select rows; the element
 \code{target} in the list can be \code{'column'} to enable column
 selection, or \code{'row+column'} to make it possible to select both rows
 and columns (click on the footer to select columns), or \code{'cell'} to
-select cells. Note that DT has its own selection implementation and doesn't
+select cells. When \code{target} is \code{'row+column'}, \code{selected}
+should be provide as a list, specifying \code{rows} and \code{cols}
+respectively, e.g., \code{list(rows = 1, cols = 2)}.
+Note that DT has its own selection implementation and doesn't
 use the Select extension because the latter doesn't support the
 server-side processing mode well. Please set this argument to \code{'none'}
 if you really want to use the Select extension.}

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -136,18 +136,30 @@ data frame) using the JavaScript library DataTables.
 \details{
 \code{selection}:
   \enumerate{
+    \item A scalar string means the selection \code{mode}, whose options are
+      \code{'multiple'} (the default), \code{'single'} and \code{'none'}
+       (disable selection).
     \item When a list form is provided for this argument, only parts of the
       "full" list are allowed. The default values for non-matched elements are
       \code{list(mode = 'multiple', selected = NULL, target = 'row', selectable = NULL)}.
+    \item \code{target} must be one of \code{'row'}, \code{'column'}, \code{'row+column'}
+       and \code{'cell'}.
+    \item \code{selected} could be \code{NULL} or indices. The format is specified below.
+    \item \code{selectable} could be \code{NULL}, \code{TRUE}, \code{FALSE} or indices,
+      where \code{NULL} and \code{TRUE} means all the table is selectable. When \code{FALSE},
+      it means users can't select the table by cursor (but they could still be able to
+      select the table via \code{\link{dataTableProxy}}). If indicies, they must be
+      all positive or non-positive values. All positive indicies mean only the ranges
+      are selectable while all non-positive indicies mean the ranges are \emph{not}
+      selectable. The indicies' format is specified below.
+    \item When \code{target} is \code{'row'} or \code{'column'}, \code{selected} and
+      \code{selectable} should be a plain numeric vector.
     \item When \code{target} is \code{'row+column'}, \code{selected} and
       \code{selectable} should be provide as a list, specifying \code{rows}
       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
     \item When \code{target} is \code{'cell'}, \code{selected} and
-      \code{selectable} should be provide as a 2-col \code{matrix}, where each row
-      stands for the row and column indices.
-    \item \code{selectable} must be all positive or negative values.
-      If the values are all positive, it means only certain rows/columns
-      are selectable. Otherwise, it means they are \emph{not} selectable.
+      \code{selectable} should be provide as a 2-col \code{matrix}, where the two
+      values of each row stand for the row and column indices.
     \item Note that DT has its own selection implementation and doesn't
       use the Select extension because the latter doesn't support the
       server-side processing mode well. Please set this argument to

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -142,11 +142,12 @@ data frame) using the JavaScript library DataTables.
     \item When \code{target} is \code{'row+column'}, \code{selected} and
       \code{selectable} should be provide as a list, specifying \code{rows}
       and \code{cols} respectively, e.g., \code{list(rows = 1, cols = 2)}.
-    \item \code{selectable} must be \code{NULL} or an integer vector with
-      all positive or negative values. The values are the row or column
-      indices of the table. If the values are all positive, it means only
-      certain rows/columns are selectable. Otherwise, it means they are
-      \emph{not} selectable.
+    \item When \code{target} is \code{'cell'}, \code{selected} and
+      \code{selectable} should be provide as a 2-col \code{matrix}, where each row
+      stands for the row and column indices.
+    \item \code{selectable} must be all positive or negative values.
+      If the values are all positive, it means only certain rows/columns
+      are selectable. Otherwise, it means they are \emph{not} selectable.
     \item Note that DT has its own selection implementation and doesn't
       use the Select extension because the latter doesn't support the
       server-side processing mode well. Please set this argument to

--- a/man/proxy.Rd
+++ b/man/proxy.Rd
@@ -22,11 +22,11 @@ dataTableProxy(
   deferUntilFlush = TRUE
 )
 
-selectRows(proxy, selected)
+selectRows(proxy, selected, ignore.selectable = TRUE)
 
-selectColumns(proxy, selected)
+selectColumns(proxy, selected, ignore.selectable = TRUE)
 
-selectCells(proxy, selected)
+selectCells(proxy, selected, ignore.selectable = TRUE)
 
 addRow(proxy, data)
 
@@ -65,6 +65,10 @@ should be held until after the next time all of the outputs are updated}
 \item{selected}{an integer vector of row/column indices, or a matrix of two
 columns (row and column indices, respectively) for cell indices; you may
 use \code{NULL} to clear existing selections}
+
+\item{ignore.selectable}{when \code{TRUE} (the default), the "selectable"
+range that's specified by \code{selection = list(selectable= )} will be
+ignored; otherwise, you can't select the "non-selectable" range.}
 
 \item{data}{a single row of data to be added to the table; it can be a matrix
 or data frame of one row, or a vector or list of row data (in the latter

--- a/man/proxy.Rd
+++ b/man/proxy.Rd
@@ -22,11 +22,11 @@ dataTableProxy(
   deferUntilFlush = TRUE
 )
 
-selectRows(proxy, selected, ignore.selectable = TRUE)
+selectRows(proxy, selected, ignore.selectable = FALSE)
 
-selectColumns(proxy, selected, ignore.selectable = TRUE)
+selectColumns(proxy, selected, ignore.selectable = FALSE)
 
-selectCells(proxy, selected, ignore.selectable = TRUE)
+selectCells(proxy, selected, ignore.selectable = FALSE)
 
 addRow(proxy, data)
 
@@ -66,9 +66,9 @@ should be held until after the next time all of the outputs are updated}
 columns (row and column indices, respectively) for cell indices; you may
 use \code{NULL} to clear existing selections}
 
-\item{ignore.selectable}{when \code{TRUE} (the default), the "selectable"
-range that's specified by \code{selection = list(selectable= )} will be
-ignored; otherwise, you can't select the "non-selectable" range.}
+\item{ignore.selectable}{when \code{FALSE} (the default), the "non-selectable"
+range specified by \code{selection = list(selectable= )} is respected, i.e.,
+you can't select "non-selectable" range. Otherwise, it is ignored.}
 
 \item{data}{a single row of data to be added to the table; it can be a matrix
 or data frame of one row, or a vector or list of row data (in the latter

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -83,3 +83,14 @@ assert('allPosNeg() works', {
   (allPosNeg(list(1:3, -(1:3))) %==% TRUE)
   (allPosNeg(list(c(1, -1, 3), -(1:3))) %==% FALSE)
 })
+
+assert('selection$selectable must be NULL or all pos/neg values', {
+  opt = options('DT.datatable.shiny' = TRUE)
+  on.exit(options(opt), add = TRUE)
+  (has_error(datatable(iris, selection = list(selectable = 0))))
+  (has_error(datatable(iris, selection = list(selectable = c(1, -1)))))
+  (has_error(datatable(iris, selection = list(selectable = list(rows = 1:3, cols = c(1, 0))))))
+  (!has_error(datatable(iris, selection = list(selectable = 1:3))))
+  (!has_error(datatable(iris, selection = list(selectable = NULL))))
+  (!has_error(datatable(iris, selection = list(selectable = list(rows = -1)))))
+})

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -21,7 +21,7 @@ assert('validateSelection() works', {
     validateSelection(list(mode = 'none', target = 'row+column', selected = list(cols = 3:4)))
   ))
   # check selected when target is cell
-   (!has_error(
+  (!has_error(
     validateSelection(list(mode = 'none', target = 'cell'))
   ))
   (has_error(

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -123,6 +123,8 @@ assert('sameSign() works', {
   (sameSign(c(0, 0, 0), zero = -1) %==% TRUE)
   (sameSign(list(1:3, -(1:3))) %==% TRUE)
   (sameSign(list(c(1, -1, 3), -(1:3))) %==% FALSE)
+  (sameSign(cbind(1:2, 3:4)) %==% TRUE)
+  (sameSign(cbind(1:2, -(1:2))) %==% FALSE)
 })
 
 local({

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -20,6 +20,15 @@ assert('validateSelection() works', {
   (!has_error(
     validateSelection(list(mode = 'none', target = 'row+column', selected = list(cols = 3:4)))
   ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'row+column', selectable = 1))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row+column', selectable = list(rows = 3:4)))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row+column', selectable = list(cols = 3:4)))
+  ))
   # check selected when target is cell
   (!has_error(
     validateSelection(list(mode = 'none', target = 'cell'))
@@ -32,6 +41,26 @@ assert('validateSelection() works', {
   ))
   (!has_error(
     validateSelection(list(mode = 'none', target = 'cell', selected = cbind(1, 2)))
+  ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'cell', selectable = 1))
+  ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'cell', selectable = cbind(1)))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'cell', selectable = cbind(1, 2)))
+  ))
+  # selectable must be all positive or non-positive values
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row', selectable = 1:3))
+  ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'row', selectable = c(-1, 1)))
+  ))
+  # selectable supports TRUE or FALSE
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row', selectable = FALSE))
   ))
 })
 
@@ -131,7 +160,7 @@ local({
   opt = options('DT.datatable.shiny' = TRUE)
   on.exit(options(opt), add = TRUE)
   assert('selection$selectable must be NULL or all pos/neg values', {
-    (has_error(datatable(iris, selection = list(selectable = 0))))
+    (!has_error(datatable(iris, selection = list(selectable = FALSE))))
     (has_error(datatable(iris, selection = list(selectable = c(1, -1)))))
     (has_error(datatable(iris, selection = list(selectable = list(rows = 1:3, cols = c(1, 0))))))
     (!has_error(datatable(iris, selection = list(selectable = 1:3))))

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -72,3 +72,14 @@ assert('escapeToConfig() works', {
   (escapeToConfig(c('<', 'a'), nms) %==% '"1,3"')
   (escapeToConfig(c(TRUE, FALSE, TRUE), nms) %==% '"1,3"')
 })
+
+assert('allPosNeg() works', {
+  (allPosNeg(NULL) %==% TRUE)
+  (allPosNeg(c(1, 2, 3)) %==% TRUE)
+  (allPosNeg(c(-1, -2, -3)) %==% TRUE)
+  (allPosNeg(c(1, -2, 3)) %==% FALSE)
+  (allPosNeg(c(1, 0, 3)) %==% FALSE)
+  (allPosNeg(c(0, 0, 0)) %==% FALSE)
+  (allPosNeg(list(1:3, -(1:3))) %==% TRUE)
+  (allPosNeg(list(c(1, -1, 3), -(1:3))) %==% FALSE)
+})

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -84,13 +84,15 @@ assert('allPosNeg() works', {
   (allPosNeg(list(c(1, -1, 3), -(1:3))) %==% FALSE)
 })
 
-assert('selection$selectable must be NULL or all pos/neg values', {
+local({
   opt = options('DT.datatable.shiny' = TRUE)
   on.exit(options(opt), add = TRUE)
-  (has_error(datatable(iris, selection = list(selectable = 0))))
-  (has_error(datatable(iris, selection = list(selectable = c(1, -1)))))
-  (has_error(datatable(iris, selection = list(selectable = list(rows = 1:3, cols = c(1, 0))))))
-  (!has_error(datatable(iris, selection = list(selectable = 1:3))))
-  (!has_error(datatable(iris, selection = list(selectable = NULL))))
-  (!has_error(datatable(iris, selection = list(selectable = list(rows = -1)))))
+  assert('selection$selectable must be NULL or all pos/neg values', {
+    (has_error(datatable(iris, selection = list(selectable = 0))))
+    (has_error(datatable(iris, selection = list(selectable = c(1, -1)))))
+    (has_error(datatable(iris, selection = list(selectable = list(rows = 1:3, cols = c(1, 0))))))
+    (!has_error(datatable(iris, selection = list(selectable = 1:3))))
+    (!has_error(datatable(iris, selection = list(selectable = NULL))))
+    (!has_error(datatable(iris, selection = list(selectable = list(rows = -1)))))
+  })
 })

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -167,4 +167,9 @@ local({
     (!has_error(datatable(iris, selection = list(selectable = NULL))))
     (!has_error(datatable(iris, selection = list(selectable = list(rows = -1)))))
   })
+  assert('selection option will keep NULL elements', {
+    # to ensure on JS side, the value like data.selection.selectable is null instead of undefined
+    out = datatable(iris, selection = list(selectable = NULL, selected = NULL))
+    (names(out$x$selection) %==% c('mode', 'selected', 'target', 'selectable'))
+  })
 })

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -108,15 +108,21 @@ assert('escapeToConfig() works', {
   (escapeToConfig(c(TRUE, FALSE, TRUE), nms) %==% '"1,3"')
 })
 
-assert('allPosNeg() works', {
-  (allPosNeg(NULL) %==% TRUE)
-  (allPosNeg(c(1, 2, 3)) %==% TRUE)
-  (allPosNeg(c(-1, -2, -3)) %==% TRUE)
-  (allPosNeg(c(1, -2, 3)) %==% FALSE)
-  (allPosNeg(c(1, 0, 3)) %==% FALSE)
-  (allPosNeg(c(0, 0, 0)) %==% FALSE)
-  (allPosNeg(list(1:3, -(1:3))) %==% TRUE)
-  (allPosNeg(list(c(1, -1, 3), -(1:3))) %==% FALSE)
+assert('sameSign() works', {
+  (sameSign(NULL) %==% TRUE)
+  (sameSign(c(1, 2, 3)) %==% TRUE)
+  (sameSign(c(-1, -2, -3)) %==% TRUE)
+  (sameSign(c(1, -2, 3)) %==% FALSE)
+  (sameSign(c(1, 0, 3)) %==% FALSE)
+  (sameSign(c(1, 0, 3), zero = 1) %==% TRUE)
+  (sameSign(c(1, 0, 3), zero = -1) %==% FALSE)
+  (sameSign(c(-1, 0, -3)) %==% FALSE)
+  (sameSign(c(-1, 0, -3), zero = 1) %==% FALSE)
+  (sameSign(c(-1, 0, -3), zero = -1) %==% TRUE)
+  (sameSign(c(0, 0, 0)) %==% TRUE)
+  (sameSign(c(0, 0, 0), zero = -1) %==% TRUE)
+  (sameSign(list(1:3, -(1:3))) %==% TRUE)
+  (sameSign(list(c(1, -1, 3), -(1:3))) %==% FALSE)
 })
 
 local({


### PR DESCRIPTION
Closes #201 
Closes #768 

### TODO

- [x] `target = 'cell'`
- [x] Decide to treat the 0th column (rowname) as "disable". The reasons are:
    1. the 0th column is the row name so our users usually want to "disable" the selection
    1. even if somehow their real intention is to "enable", they can provide the column indices reversely, i.e., "disable" other columns. This is no difficult and no performance issues as the number of columns is usually very limited. 
- [x] `selectable` should support logical values where `TRUE` is default and `FALSE` is to disable all (#768)
- [x] the proxy selection function should gain a new argument `ignore.selectable` to ignore the selectable range (#768)
- [x] should validate `selectable` in `validateSelection()` after #795 being merged
- [x] update inst/example (Will do after reviewed by @yihui) 
- [x] double-check on IE11

### Description

See Details section in `DT::datatable`

> selectable could be NULL, TRUE, FALSE or indices, where NULL and TRUE mean all the table is selectable. When FALSE, it means users can't select the table by the cursor (but they could still be able to select the table via dataTableProxy). If indices, they must be all positive or non-positive values. All positive indices mean only the ranges are selectable while all non-positive indices mean the ranges are not selectable.

### Implementation

Considering the complexity of the selection can be performed (shift selection, proxy selection, etc.), I choose to "de-select" the not-allowed range after the user selects so that the implementation could be more robust.

### Nice-to-have in the future

In addition, it's better to make the "disable" state clearer (at present, the user doesn't know certain ranges are not selectable) but I may not have enough time for this right now, so I incline to leave this in the future when there're real user requests.


### CODE

```r
library(shiny)

ui = fluidPage(sidebarLayout(
  sidebarPanel(
    radioButtons('target', 'target', c('row', 'column', 'row+column', 'cell'), inline = TRUE),
    radioButtons('mode', 'mode', c('multiple', 'single'), inline = TRUE),
    radioButtons('rownames', 'rownames', c('TRUE', 'FALSE'), inline = TRUE),
    textInput('selected', 'selected', 'c(1:5, 30)'),
    textInput('selectable', 'selectable', '-(2:4)'),
    radioButtons('server','server',c('TRUE','FALSE'), inline = TRUE),
    radioButtons('proxy_type', 'proxy_type', c('Rows', 'Columns', 'Cells'), inline = TRUE),
    radioButtons('ignore_selectable','ignore_selectable', c('TRUE','FALSE'), inline = TRUE),
    textInput('proxy_select', 'proxy_select', "3:6"),
    actionButton('proxy_click', 'Click')
  ),
  mainPanel(
    verbatimTextOutput('print'),
    DT::DTOutput('tbl')    
  )
))
server = function(input, output, session) {
  output$tbl = DT::renderDT(
    DT::datatable(iris[1:20,], selection = list(
      target = req(input$target), mode = req(input$mode),
      selected = eval(parse(text = req(input$selected))),
      selectable = eval(parse(text = req(input$selectable)))),
      rownames = as.logical(input$rownames)
    ), server = as.logical(input$server)
  )
  proxy = DT::dataTableProxy('tbl')
  observeEvent(input$proxy_click, try({
    tgt = eval(parse(text = req(input$proxy_select)))
    fun = match.fun(sprintf("select%s", req(input$proxy_type)))
    fun(proxy, tgt, as.logical(input$ignore_selectable))
  }))
  output$print = renderPrint({
    print("rows_selected")
    print(input$tbl_rows_selected)
    print("cols_selected")
    print(input$tbl_columns_selected)
    print("cells_selected")
    print(input$tbl_cells_selected)
  })
}
shiny::runApp(list(ui = ui, server = server), port = 6435)

```

### Checks

- Shift row-selection respects selectable
- Out-of-range selected (pre-selection) doesn't break the code
- selectable `NULL`, `TRUE` and `FALSE` works as expected
- Col and cell selection work expected with or without rownames
- Negative and positive selectable works as expected
- Proxy selection works as expected
- Proxy selection will not keep the previous selection
- All the combination cases on IE11 and for row/column/row+column/cell mode

