### PR TITLE
make `renderDT(server=)` reactive in Shiny

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -88,12 +88,12 @@ renderDataTable = function(
     }
   }
   processWidget = function(instance) {
+    args = argFunc(); args = args[-length(args)] # the last element is `server`
+    # which is only used in `renderDT()` not `datatable()`, the reason
+    # of having it in `argFunc()` is we want `server` to be reactive
     if (!all(c('datatables', 'htmlwidget') %in% class(instance))) {
-      args = argFunc(); args = args[-length(args)] # the last element is `server`
-      # which is only used in `renderDT()` not `datatable()`, the reason
-      # of having it in `argFunc()` is we want `server` to be reactive
       instance = do.call(datatable, c(list(instance), args))
-    } else if (length(argFunc()) != 0) {
+    } else if (length(args) != 0) {
       warning("renderDataTable ignores ... arguments when expr yields a datatable object; see ?renderDataTable")
     }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -77,7 +77,7 @@ renderDataTable = function(
   outputInfoEnv[["session"]] = NULL
 
   exprFunc = shiny::exprToFunction(expr, env, quoted = TRUE)
-  argFunc = shiny::exprToFunction(list(...), env, quoted = FALSE)
+  argFunc = shiny::exprToFunction(list(..., server = server), env, quoted = FALSE)
   widgetFunc = function() {
     opts = options(DT.datatable.shiny = TRUE); on.exit(options(opts), add = TRUE)
     instance = exprFunc()
@@ -89,7 +89,10 @@ renderDataTable = function(
   }
   processWidget = function(instance) {
     if (!all(c('datatables', 'htmlwidget') %in% class(instance))) {
-      instance = do.call(datatable, c(list(instance), argFunc()))
+      args = argFunc(); args = args[-length(args)] # the last element is `server`
+      # which is only used in `renderDT()` not `datatable()`, the reason
+      # of having it in `argFunc()` is we want `server` to be reactive
+      instance = do.call(datatable, c(list(instance), args))
     } else if (length(argFunc()) != 0) {
       warning("renderDataTable ignores ... arguments when expr yields a datatable object; see ?renderDataTable")
     }


### PR DESCRIPTION
Right now, the `server` argument in `renderDT()` doesn't react to the inputs in Shiny. This PR enables it.

It's trivial but I personally find it's very useful when testing.

```r
library(shiny)

ui = fluidPage(sidebarLayout(
  sidebarPanel(
    radioButtons('server','server',c('TRUE','FALSE'))
  ),
  mainPanel(
    DT::DTOutput('tbl')    
  )
))
server = function(input, output, session) {
  output$tbl = DT::renderDT({
    tbl = data.frame(A = rnorm(10), B = rnorm(10))
  }, server = as.logical(input$server))
}
shiny::runApp(list(ui = ui, server = server), port = 6435)
```