### PR TITLE
validate the `selection` param on R side

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - The formatting functions now throw clearer error messages when called on non-datatables objects (thanks, @shrektan, #785).
 
+- Incorrect `selection` param now triggers a clear error message on the R side (thanks, @shrektan, #795).
+
 # CHANGES IN DT VERSION 0.13
 
 ## BUG FIXES

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -263,7 +263,7 @@ datatable = function(
     if (grepl('^row', selection$target) && is.character(selection$selected) && length(rn)) {
       selection$selected = match(selection$selected, rn)
     }
-    params$selection = selection
+    params$selection = validateSelection(selection)
     # warn if the Select ext is used but selection is not set to none
     if ('Select' %in% extensions && selection$mode != 'none') warning(
       "The Select extension can't work properly with DT's own ",
@@ -315,6 +315,23 @@ datatable = function(
       instance
     }
   )
+}
+
+validateSelection = function(x) {
+  err = character()
+  if (length(x$mode) != 1L || !x$mode %in% c('none', 'single', 'multiple'))
+    err = c(err, "- `mode` must be one of 'none', 'single' and 'multiple'")
+  if (length(x$target) != 1L || !x$target %in% c('row', 'column', 'row+column', 'cell'))
+    err = c(err, "- `target` must be one of 'row', 'column', 'row+column' and 'cell'")
+  if (length(x$selected)) {
+    if (x$target == 'row+column' && (!is.list(x$selected) || !names(x$selected) %in% c('rows', 'cols')))
+      err = c(err, "- when `target` is 'row+column', `selected` must be a list in the form `list(rows = 1, cols = 2)`")
+    if (x$target == 'cell' && (!is.matrix(x$selected) || ncol(x$selected) != 2L))
+      err = c(err, "- when `target` is 'cell', `selected` must be a 2-col matrix")
+  }
+  if (length(err))
+    stop(paste0(c("the `selection` argument is incorrect:", err), collapse = '\n'), call. = FALSE)
+  x
 }
 
 appendColumnDefs = function(options, def) {

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -1,5 +1,40 @@
 library(testit)
 
+assert('validateSelection() works', {
+  (has_error(
+    validateSelection(list(mode = 'a'))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'single', target = 'row'))
+  ))
+  # check selected when target is row+column
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row+column'))
+  ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'row+column', selected = 1))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row+column', selected = list(rows = 3:4)))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'row+column', selected = list(cols = 3:4)))
+  ))
+  # check selected when target is cell
+   (!has_error(
+    validateSelection(list(mode = 'none', target = 'cell'))
+  ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'cell', selected = 1))
+  ))
+  (has_error(
+    validateSelection(list(mode = 'none', target = 'cell', selected = cbind(1)))
+  ))
+  (!has_error(
+    validateSelection(list(mode = 'none', target = 'cell', selected = cbind(1, 2)))
+  ))
+})
+
 assert('appendColumnDefs() works', {
   (appendColumnDefs(list(), 1) %==% list(columnDefs = list(1)))
   (appendColumnDefs(list(a = 1), 2) %==% list(a = 1, columnDefs = list(2)))


### PR DESCRIPTION
If the users provide the param incorrectly, right now they can only see the error message in the browser's console, which is difficult for those who are not familiar with JS.