### PR TITLE
input should not affect the column width

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -527,7 +527,7 @@ filterRow = function(
         style = 'margin-bottom: auto;',
         tags$input(
           type = if (clear) 'search' else 'text', placeholder = 'All',
-          style = 'width: 100%;'
+          style = 'width: 100%;', size = "1"
         )
       )
     } else {
@@ -536,7 +536,7 @@ filterRow = function(
         style = 'margin-bottom: auto;',
         tags$input(
           type = 'search', placeholder = 'All', class = 'form-control',
-          style = 'width: 100%;'
+          style = 'width: 100%;', size = "1"
         ),
         if (clear) tags$span(
           class = 'glyphicon glyphicon-remove-circle form-control-feedback'

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -754,7 +754,7 @@ HTMLWidgets.widget({
         (function(cell, current) {
           var $cell = $(cell), html = $cell.html();
           var _cell = table.cell(cell), value = _cell.data();
-          var $input = $('<input type="text">'), changed = false;
+          var $input = $('<input type="text" size="1">'), changed = false;
           if (!immediate) {
             $cell.data('input', $input).data('html', html);
             $input.attr('title', 'Hit Ctrl+Enter to finish editing, or Esc to cancel');


### PR DESCRIPTION
Closes #797 

- [x] Works on a plain page
- [ ] Works for bootstrap themes

## Code

```r
library(shiny)
df <- data.frame(
  LONGLONG = c("longlonglonglonglong", 'aaabcdasfasfd', 'ffasfaadsfas'),
  MED = c("mediummedium", 'dfafd','fdsafaf'),
  SHT = as.character(c("short", "fdafa",'aa')),
  # FATR = as.factor(c("short", "fdafa",'aa')),
  # number = 11:13,
  stringsAsFactors = FALSE
)
ui = tagList(
  DT::DTOutput('tbl1'),
  DT::DTOutput('tbl2'),
  DT::DTOutput('tbl3')
)
server = function(input, output, session) {
  output$tbl1 <- DT::renderDT(
    DT::datatable(df)
  )
  output$tbl2 <- DT::renderDT(
    DT::datatable(df, filter = 'top')
  )
  output$tbl3 <- DT::renderDT(
    DT::datatable(df, editable = 'all')
  )
}
runApp(list(ui = ui, server = server))
```


## With this PR

The cell width is basically the same as before.

<img width="796" alt="image" src="https://user-images.githubusercontent.com/8368933/79130049-ea90fd80-7dd8-11ea-938a-50d71f6860e8.png">

## Before this PR

Every column's width is the same.

<img width="793" alt="image" src="https://user-images.githubusercontent.com/8368933/79130103-00062780-7dd9-11ea-91c5-97c0fe757416.png">

