### PR TITLE
Always send "_clicked" events

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Now the user is able to control the selection range by `datatable(..., selection = list(selectable = 3:5))`, where positive and non-positive `selectable` means "enable" and "disable", respectively (thanks, @tomasreigl @shrektan, #201 #793).
 
+- Clicking on a row or cell now always triggers a reactive event in Shiny (`input$tableId_row_last_clicked` or `input$tableId_cell_clicked`), even if the same row or cell is clicked multiple times (thanks @gadenbuie, #811).
+
 ## BUG FIXES
 
 - Fix the issue that formatting functions don't support vectorized arguments any longer. This was a regression of PR #777 (thanks, @pbreheny @shrektan, #790).

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -842,7 +842,7 @@ HTMLWidgets.widget({
       id = el.id + '_' + id;
       if (type) id = id + ':' + type;
       // do not update if the new value is the same as old value
-      if (event !== 'cell_edit' && shinyData.hasOwnProperty(id) && shinyData[id] === JSON.stringify(value))
+      if (event !== 'cell_edit' && !/_clicked$/.test(event) && shinyData.hasOwnProperty(id) && shinyData[id] === JSON.stringify(value))
         return;
       shinyData[id] = JSON.stringify(value);
       if (HTMLWidgets.shinyMode && Shiny.setInputValue) {
@@ -1084,7 +1084,7 @@ HTMLWidgets.widget({
           selectedRows(); // update selected1's value based on selClass
           selectRows(false); // only keep the selectable rows
           changeInput('rows_selected', selected1);
-          changeInput('row_last_clicked', serverRowIndex(thisRow.index()));
+          changeInput('row_last_clicked', serverRowIndex(thisRow.index()), null, null, {priority: 'event'});
           lastClickedRow = serverRowIndex(thisRow.index());
         });
         selectRows(false);  // in case users have specified pre-selected rows
@@ -1284,7 +1284,7 @@ HTMLWidgets.widget({
     }
     // the current cell clicked on
     table.on('click.dt', 'tbody td', function() {
-      changeInput('cell_clicked', cellInfo(this));
+      changeInput('cell_clicked', cellInfo(this), null, null, {priority: 'event'});
     })
     changeInput('cell_clicked', {});
 


### PR DESCRIPTION
This PR modifies the event listeners for `row_last_clicked` and `cell_clicked` events to always send the value of the clicked row or cell when clicked. Previously, the value was sent only if the clicked row had not changed.

The motivation for this is to be able to write `row_last_clicked` "event handlers" in shiny, for example adding or removing the last clicked row to the collection of selected rows when the data is being filtered using non-DT inputs elsewhere in the app.

Apologies for not first opening an issue, I thought it might be easier to just propose the changes.

<details><summary>Here's a small example app</summary>

```r
library(shiny)
library(DT)
library(dplyr)

ui <- fluidPage(
  tags$p("This is a simple demo, but the filtering UI could be much more complicated."),
  selectizeInput("homeworld", "Homeworld", choices = unique(starwars$homeworld), multiple = TRUE),
  dataTableOutput("table")
)

server <- function(input, output, session) {
  global_selection <- reactiveVal(NULL)
  
  # Global dataset
  starwars <- dplyr::starwars %>% mutate(id = row_number())
  
  # Data set shown in app based on current filters
  starwars_view <- reactive({
    if (isTruthy(input$homeworld)) {
      starwars %>% filter(homeworld %in% input$homeworld)
    } else {
      starwars
    }
  })
  
  # Limit displayed columns to a small subset for this demo
  prep_starwars <- function(x) {
    x[, c("name", "height", "homeworld", "species")]
  }
  
  # Initialize the datatable
  output$table <- renderDataTable({
    datatable(
      prep_starwars(starwars),
      selection = list(mode = "multiple", target = "row")
    )
  })
  
  # Watch the last clicked event and handle each click
  observeEvent(input$table_row_last_clicked, {
    clicked_id <- starwars_view()$id[input$table_row_last_clicked]
    if (!clicked_id %in% global_selection()) {
      # Add row ID to global selection
      global_selection(c(global_selection(), clicked_id))
    } else {
      # remove row ID from global selection
      global_selection(setdiff(global_selection(), clicked_id))
    }
  })
  
  # Update the datatable in place when data or selection change
  observeEvent(starwars_view(), {
    dataTableProxy("table") %>% 
      replaceData(prep_starwars(starwars_view())) %>% 
      selectRows(which(starwars_view()$id %in% global_selection()))
  })
  
  observeEvent(global_selection(), {
    dataTableProxy("table") %>% 
      selectRows(which(starwars_view()$id %in% global_selection()))
  })
}

shinyApp(ui, server)
```
</details>