### PR TITLE
Should apply the render functions only for the "display" purpose

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.15.1
+Version: 0.15.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.16
 
+## BUG FIXES
+
+- Fix the issue that the sorting results may not be expected after formatting functions applied. This is a regression of PR #777 (thanks, @fernandofernandezgonzalez @shrektan, #837).
 
 # CHANGES IN DT VERSION 0.15
 

--- a/R/format.R
+++ b/R/format.R
@@ -196,7 +196,7 @@ colFormatter = function(name, names, rownames = TRUE, template, ...) {
   js = sprintf("
   function(data, type, row, meta) {
     if (type === 'display') {
-      return %s
+      return %s;
     } else {
       return data;
     }

--- a/R/format.R
+++ b/R/format.R
@@ -193,13 +193,8 @@ colFormatter = function(name, names, rownames = TRUE, template, ...) {
   i = name2int(name, names, rownames)
   # see https://datatables.net/reference/option/columns.render
   # #837 we only want to use the formatting for the "display" purpose
-  js = sprintf("
-  function(data, type, row, meta) {
-    if (type === 'display') {
-      return %s;
-    } else {
-      return data;
-    }
+  js = sprintf("function(data, type, row, meta) {
+    return type === 'display' ? %s : data;
   }", template(...))
   Map(function(i, js) list(targets = i, render = JS(js)), i, js, USE.NAMES = FALSE)
 }

--- a/R/format.R
+++ b/R/format.R
@@ -191,7 +191,16 @@ name2int = function(name, names, rownames, noerror = FALSE) {
 
 colFormatter = function(name, names, rownames = TRUE, template, ...) {
   i = name2int(name, names, rownames)
-  js = sprintf("function(data, type, row, meta) { return %s }", template(...))
+  # see https://datatables.net/reference/option/columns.render
+  # #837 we only want to use the formatting for the "display" purpose
+  js = sprintf("
+  function(data, type, row, meta) {
+    if (type === 'display') {
+      return %s
+    } else {
+      return data;
+    }
+  }", template(...))
   Map(function(i, js) list(targets = i, render = JS(js)), i, js, USE.NAMES = FALSE)
 }
 


### PR DESCRIPTION
Closes #837 

See the documentation at https://datatables.net/reference/option/columns.render (the function section)

## CODE (the ORDER column is supposed to be 3,2,1 )

```r
library(DT)
data <- data.frame(
  VALUE = c(998, 999, 1000),
  ORDER = 1:3
)
x <- DT::datatable(data, options = list(order = list(1, 'desc')) ) %>%
  formatCurrency(c("VALUE","ORDER"),currency='',digits=0,mark=".",dec=",")
x
```

### Before 

<img width="602" alt="image" src="https://user-images.githubusercontent.com/8368933/90147204-86953a80-ddb4-11ea-8c52-f11350afc267.png">


### After

<img width="605" alt="image" src="https://user-images.githubusercontent.com/8368933/90147160-78dfb500-ddb4-11ea-9c02-aa980321c3c9.png">
