### PR TITLE
styleColorBar() should handle out-of-range value properly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.15.3
+Version: 0.15.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fix the issue that the sorting results may not be expected after formatting functions applied. This is a regression of PR #777 (thanks, @fernandofernandezgonzalez @shrektan, #837).
 
+- `styleColorBar()` now displays correctly on Safari, when the data is greater than the upper limit, due to negative css percentage values (thanks, @Seyphaton, #843).
+
 # CHANGES IN DT VERSION 0.15
 
 ## BUG FIXES

--- a/R/format.R
+++ b/R/format.R
@@ -389,7 +389,7 @@ styleColorBar = function(data, color, angle=90) {
   rg = range(data, na.rm = TRUE, finite = TRUE)
   r1 = rg[1]; r2 = rg[2]; r = r2 - r1
   JS(sprintf(
-    "isNaN(parseFloat(value)) || value <= %f ? '' : 'linear-gradient(%fdeg, transparent ' + (%f - value)/%f * 100 + '%%, %s ' + (%f - value)/%f * 100 + '%%)'",
+    "isNaN(parseFloat(value)) || value <= %f ? '' : 'linear-gradient(%fdeg, transparent ' + Math.max(%f - value, 0)/%f * 100 + '%%, %s ' + Math.max(%f - value, 0)/%f * 100 + '%%)'",
     r1, angle, r2, r, color, r2, r
   ))
 }


### PR DESCRIPTION
Fixes #843 

styleColorBar() now displays correctly on Safari when the data is greater than the upper limit (the css percentage value is negative)

Thanks @Seyphaton for the report and the solution!

## Minimal example (view it on safari)

```r
dt <- DT::datatable(data = mtcars, options = list(pageLength = -1))
dt <- DT::formatStyle(
  dt, "mpg", background = styleColorBar(
    data = c(0, max(mtcars$mpg * 0.5)), color = "blue"
  )
)
dt
```

## Before

<img width="655" alt="image" src="https://user-images.githubusercontent.com/8368933/90410599-2583a480-e0dd-11ea-86fe-379c0d400654.png">


## After

<img width="624" alt="image" src="https://user-images.githubusercontent.com/8368933/90410411-e7868080-e0dc-11ea-9311-413b5a63e8f9.png">
