### PR TITLE
`addRow()` now has a new parameter `resetPaging`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.15.5
+Version: 0.15.6
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Add a new plugin [accent-neutralise](https://datatables.net/plug-ins/filtering/type-based/accent-neutralise), which can be used for searching accented characters with their unaccented counterparts. Note, it will only work in the client-side processing mode (#822).
 
+- `addRow()` now has a new parameter `resetPaging`. By setting it to `FALSE`, we can keep the paging position after adding a row (thanks, @stanstrup, #853).
+
 ## MINOR CHANGES
 
 - Upgrade the SearchPanes extension to v1.1.1 so that it can [display all the entries properly with the Scroller extension](https://datatables.net/forums/discussion/62807/searchpanes-button-filtering-value-only-show-10-from-all-available-values-with-scroller-extension) (thanks, @JonasMandel @stla, #820).

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -307,13 +307,13 @@ selectCells = function(proxy, selected, ignore.selectable = FALSE) {
 #'   element)
 #' @rdname proxy
 #' @export
-addRow = function(proxy, data) {
+addRow = function(proxy, data, resetPaging = TRUE) {
   if ((is.matrix(data) || is.data.frame(data)) && nrow(data) != 1)
     stop("'data' must be of only one row")
   # must apply unname() after as.list() because a data.table object
   # can't be really unnamed. The names() attributes will be
   # preserved but with empty strings (see #760).
-  invokeRemote(proxy, 'addRow', list(unname(as.list(data)), I(rownames(data))))
+  invokeRemote(proxy, 'addRow', list(unname(as.list(data)), I(rownames(data)), resetPaging))
 }
 
 #' @rdname proxy

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1301,7 +1301,7 @@ HTMLWidgets.widget({
       if (this.className === '') e.stopPropagation();
     });
 
-    methods.addRow = function(data, rowname, paging) {
+    methods.addRow = function(data, rowname, resetPaging) {
       var data0 = table.row(0).data(), n = data0.length, d = n - data.length;
       if (d === 1) {
         data = rowname.concat(data)
@@ -1310,7 +1310,7 @@ HTMLWidgets.widget({
         console.log(data0);
         throw 'New data must be of the same length as current data (' + n + ')';
       };
-      table.row.add(data).draw(paging);
+      table.row.add(data).draw(resetPaging);
     }
 
     methods.updateSearch = function(keywords) {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1301,7 +1301,7 @@ HTMLWidgets.widget({
       if (this.className === '') e.stopPropagation();
     });
 
-    methods.addRow = function(data, rowname) {
+    methods.addRow = function(data, rowname, paging) {
       var data0 = table.row(0).data(), n = data0.length, d = n - data.length;
       if (d === 1) {
         data = rowname.concat(data)
@@ -1310,7 +1310,7 @@ HTMLWidgets.widget({
         console.log(data0);
         throw 'New data must be of the same length as current data (' + n + ')';
       };
-      table.row.add(data).draw();
+      table.row.add(data).draw(paging);
     }
 
     methods.updateSearch = function(keywords) {

--- a/man/proxy.Rd
+++ b/man/proxy.Rd
@@ -28,7 +28,7 @@ selectColumns(proxy, selected, ignore.selectable = FALSE)
 
 selectCells(proxy, selected, ignore.selectable = FALSE)
 
-addRow(proxy, data)
+addRow(proxy, data, resetPaging = TRUE)
 
 clearSearch(proxy)
 
@@ -76,6 +76,8 @@ case, please be cautious about the row name: if your table contains row
 names, here \code{data} must also contain the row name as the first
 element)}
 
+\item{resetPaging}{whether to reset the paging position}
+
 \item{page}{a number indicating the page to select}
 
 \item{caption}{a new table caption (see the \code{caption} argument of
@@ -102,8 +104,6 @@ set as well as option 'colReordoer' set to TRUE).}
 
 \item{origOrder}{Whether column reordering should be relative to the original
 order (the default is to compare to current order)}
-
-\item{resetPaging}{whether to reset the paging position}
 
 \item{clearSelection}{which existing selections to clear: it can be any
 combinations of \code{row}, \code{column}, and \code{cell}, or \code{all}


### PR DESCRIPTION
Fixes #853 

`addRow()` now has a new parameter `resetPaging`, which can be used to control whether the page should be reset after the row gets added.

### Example Code


```r
library(shiny)
library(DT)

server <- function(input, output, session) {
  output$foo = DT::renderDataTable(
    head(iris, 20), server = FALSE,
    caption = 'Using a proxy object to manipulate the table',
    options = if (input$paging == "FALSE") list(
      pageLength=-1,
      scrollY = "200px",
      bPaginate = FALSE
    ) else list()
  )
  proxy = dataTableProxy('foo')
  observeEvent(input$add, {
    proxy %>% addRow(iris[sample(nrow(iris), 1), , drop = FALSE], input$resetPaging == "TRUE")
  })
}

ui <- fluidPage(
  sidebarLayout(
    sidebarPanel(
      radioButtons('paging', "Paging", c('TRUE', 'FALSE')),
      radioButtons('resetPaging', "Reset Paging", c('TRUE', 'FALSE')),
      actionButton('add', 'Add Row')
    ),
    mainPanel(
      DT::dataTableOutput('foo')
    )
  )
)


shinyApp(ui, server)
```