### PR TITLE
DT2BSClass() should keep unknown classes unchanged

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.15.6
+Version: 0.15.7
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - Upgrade the SearchPanes extension to v1.1.1 so that it can [display all the entries properly with the Scroller extension](https://datatables.net/forums/discussion/62807/searchpanes-button-filtering-value-only-show-10-from-all-available-values-with-scroller-extension) (thanks, @JonasMandel @stla, #820).
 
+- The `class` argument now keeps user-defined classes with bootstrap themes (thanks, @mmuurr, #806).
+
 ## BUG FIXES
 
 - Fix the issue that the sorting results may not be expected after formatting functions applied. This is a regression of PR #777 (thanks, @fernandofernandezgonzalez @shrektan, #837).

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -720,9 +720,11 @@ DT2BSClass = function(class) {
     'cell-border' = 'table-bordered', 'compact' = 'table-condensed',
     'hover' = 'table-hover', 'stripe' = 'table-striped'
   )
+  # translate known default styling classes to BS table classes and keep
+  # unknown classes as they are
   class = c(
     BSclass[intersect(class, names(BSclass))],
-    grep('^table-', class, value = TRUE)
+    setdiff(class, names(BSclass))
   )
   class = unique(c('table', class))
   paste(class, collapse = ' ')

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -173,3 +173,7 @@ local({
     (names(out$x$selection) %==% c('mode', 'selected', 'target', 'selectable'))
   })
 })
+
+assert('DT2BSClass() keeps user-defined classes', {
+  (DT:::DT2BSClass(c('table-condensed stripe', 'foo')) %==% 'table table-striped table-condensed foo')
+})


### PR DESCRIPTION
Fix #806 

I think leaving irrelevant classes as they are is harmless. It's usually what users expect, in my opinion.