### PR TITLE
throw a clear message if options$search's value is illegal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.15.7
+Version: 0.15.8
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - The `class` argument now keeps user-defined classes with bootstrap themes (thanks, @mmuurr, #806).
 
+- Now DT will throw a clear error message if the value of `search` provided in `datatables(..., options=)` is illegal (thanks, @realHenningLorenzen, #848).
+
 ## BUG FIXES
 
 - Fix the issue that the sorting results may not be expected after formatting functions applied. This is a regression of PR #777 (thanks, @fernandofernandezgonzalez @shrektan, #837).

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -270,6 +270,8 @@ datatable = function(
     if (identical(options$lengthMenu, c(10, 25, 50, 100)))
       options$lengthMenu = NULL  # that is just the default
   }
+  if (!is.null(options[['search']]) && !is.list(options[['search']]))
+    stop("The value of `search` in `options` must be NULL or a list")
 
   # record fillContainer and autoHideNavigation
   if (!is.null(fillContainer)) params$fillContainer = fillContainer

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -177,3 +177,9 @@ local({
 assert('DT2BSClass() keeps user-defined classes', {
   (DT:::DT2BSClass(c('table-condensed stripe', 'foo')) %==% 'table table-striped table-condensed foo')
 })
+
+assert('clear message when options$search is illegal', {
+  out = try(datatable(data = iris, options = list(search = TRUE)), silent = TRUE)
+  (inherits(out, 'try-error'))
+  (grepl('must be NULL or a list', out[1L], fixed = TRUE))
+})


### PR DESCRIPTION
Fixes #848

Due to the fact that `fixServerOptions()` uses the sub-element's value of options$search,

https://github.com/rstudio/DT/blob/ddd608e270528313eb9edf8fd8af5bc3bc4c91cd/R/shiny.R#L729-L738

the following code throw unhelpful message:

### code

```r
shiny::shinyApp(
    ui = shiny::fluidPage(DT::DTOutput("my_dt")),
    server = function(input, output) {
        output$my_dt <- DT::renderDT({
            DT::datatable(data = mtcars[1:3, 1:2],
                          options = list(search = TRUE))
        })
    }
)
```

### msg before 

```
$ operator is invalid for atomic vectors
```

### msg after

```
The value of `search` in `options` must be NULL or a list
```