### PR TITLE
autoHideNavigation works with default theme and the doc is improved

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.16.1
+Version: 0.16.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.17
 
+## MINOR CHANGES
+
+- The `autoHideNavigation` argument now works with the default theme. In addition, the prerequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
 
 # CHANGES IN DT VERSION 0.16
 
@@ -16,8 +19,6 @@
 - The `class` argument now keeps user-defined classes with bootstrap themes (thanks, @mmuurr, #806).
 
 - Now DT will throw a clear error message if the value of `search` provided in `datatables(..., options=)` is illegal (thanks, @realHenningLorenzen, #848).
-
-- The `autoHideNavigation` argument now works with the default theme. In addition, the prerequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
 
 ## BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 - Now DT will throw a clear error message if the value of `search` provided in `datatables(..., options=)` is illegal (thanks, @realHenningLorenzen, #848).
 
+- The `autoHideNavigation` argument now works with the default theme. In addition, the prequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
+
 ## BUG FIXES
 
 - Fix the issue that the sorting results may not be expected after formatting functions applied. This is a regression of PR #777 (thanks, @fernandofernandezgonzalez @shrektan, #837).

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 
 - Now DT will throw a clear error message if the value of `search` provided in `datatables(..., options=)` is illegal (thanks, @realHenningLorenzen, #848).
 
-- The `autoHideNavigation` argument now works with the default theme. In addition, the prequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
+- The `autoHideNavigation` argument now works with the default theme. In addition, the prerequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
 
 ## BUG FIXES
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -275,7 +275,11 @@ datatable = function(
 
   # record fillContainer and autoHideNavigation
   if (!is.null(fillContainer)) params$fillContainer = fillContainer
-  if (!is.null(autoHideNavigation)) params$autoHideNavigation = autoHideNavigation
+  if (!is.null(autoHideNavigation)) {
+    if (isTRUE(autoHideNavigation) && length(options$pageLength) == 0L)
+      warning("When `autoHideNavigation` is `TRUE`, the `pageLength` option must be provided")
+    params$autoHideNavigation = autoHideNavigation
+  }
 
   params = structure(modifyList(params, list(
     data = data, container = as.character(container), options = options,

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -279,7 +279,8 @@ datatable = function(
   if (!is.null(fillContainer)) params$fillContainer = fillContainer
   if (!is.null(autoHideNavigation)) {
     if (isTRUE(autoHideNavigation) && length(options$pageLength) == 0L)
-      warning("When `autoHideNavigation` is `TRUE`, the `pageLength` option must be provided")
+      warning("`autoHideNavigation` will be ignored if the `pageLength` option is not provided.",
+              immediate. = TRUE)
     params$autoHideNavigation = autoHideNavigation
   }
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -58,7 +58,9 @@
 #'   it's containing element. If the table can't fit fully into it's container
 #'   then vertical and/or horizontal scrolling of the table cells will occur.
 #' @param autoHideNavigation \code{TRUE} to automatically hide navigational UI
-#'   when the number of total records is less than the page size.
+#'   (only display the table body) when the number of total records is less
+#'   than the page size. Note, it only works on the client-side processing mode
+#'   and the `pageLength` option should be provided explicitly.
 #' @param selection the row/column selection mode (single or multiple selection
 #'   or disable selection) when a table widget is rendered in a Shiny app;
 #'   alternatively, you can use a list of the form \code{list(mode = 'multiple',

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -111,7 +111,7 @@ renderDataTable = function(
       options = instance[['x']][['options']]
 
       # autoHideNavigation won't work in the server mode
-      if (isTRUE(options$autoHideNavigation))
+      if (isTRUE(instance[['x']][['autoHideNavigation']]))
         warning("`autoHideNavigation` only works with DT client mode and it will be ignored",
                 immediate. = TRUE, call. = FALSE)
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -110,6 +110,11 @@ renderDataTable = function(
       # register the data object in a shiny session
       options = instance[['x']][['options']]
 
+      # autoHideNavigation won't work in the server mode
+      if (isTRUE(options$autoHideNavigation))
+        warning("`autoHideNavigation` only works with DT client mode",
+                immediate. = TRUE, call. = FALSE)
+
       # Normalize "ajax" argument; if we leave it a string then we have several
       # code paths that need to account for both string and list representations
       if (is.character(options[['ajax']])) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -112,7 +112,7 @@ renderDataTable = function(
 
       # autoHideNavigation won't work in the server mode
       if (isTRUE(options$autoHideNavigation))
-        warning("`autoHideNavigation` only works with DT client mode",
+        warning("`autoHideNavigation` only works with DT client mode and it will be ignored",
                 immediate. = TRUE, call. = FALSE)
 
       # Normalize "ajax" argument; if we leave it a string then we have several

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -140,7 +140,7 @@ HTMLWidgets.widget({
     //  (b) Never want to fill the container (we want the pagination
     //      level to determine the size of the container)
     if (window.FlexDashboard && !window.FlexDashboard.isFillPage()) {
-      data.options.bPaginate = true;
+      data.options.paging = true;
       data.fillContainer = false;
     }
 
@@ -207,7 +207,7 @@ HTMLWidgets.widget({
 
       // if we aren't paginating then move around the info/filter controls
       // to save space at the bottom and rephrase the info callback
-      if (data.options.bPaginate === false) {
+      if (data.options.paging === false) {
 
         // we know how to do this cleanly for bootstrap, not so much
         // for other themes/layouts
@@ -225,9 +225,9 @@ HTMLWidgets.widget({
 
     // auto hide navigation if requested
     if (data.autoHideNavigation === true) {
-      if (bootstrapActive && data.options.bPaginate !== false) {
+      if (bootstrapActive && data.options.paging !== false) {
         // strip all nav if length >= cells
-        if ((cells instanceof Array) && data.options.iDisplayLength >= cells.length)
+        if ((cells instanceof Array) && data.options.pageLength >= cells.length)
           options.dom = "<'row'<'col-sm-12'tr>>";
         // alternatively lean things out for flexdashboard mobile portrait
         else if (window.FlexDashboard && window.FlexDashboard.isMobilePhone())

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -224,17 +224,20 @@ HTMLWidgets.widget({
     }
 
     // auto hide navigation if requested
-    if (data.autoHideNavigation === true) {
-      if (bootstrapActive && data.options.paging !== false) {
-        // strip all nav if length >= cells
-        if ((cells instanceof Array) && data.options.pageLength >= cells.length)
-          options.dom = "<'row'<'col-sm-12'tr>>";
-        // alternatively lean things out for flexdashboard mobile portrait
-        else if (window.FlexDashboard && window.FlexDashboard.isMobilePhone())
-          options.dom = "<'row'<'col-sm-12'f>>" +
-                        "<'row'<'col-sm-12'tr>>"  +
-                        "<'row'<'col-sm-12'p>>";
-      }
+    // Note, this only works on client-side processing mode as on server-side,
+    // cells (data.data) is null; In addition, we require the pageLength option
+    // being provided explicitly to enable this. Despite we may be able to deduce
+    // the default value of pageLength, it may complicate things so we'd rather
+    // put this responsiblity to users and warn them on the R side.
+    if (data.autoHideNavigation === true && data.options.paging !== false) {
+      // strip all nav if length >= cells
+      if ((cells instanceof Array) && data.options.pageLength >= cells.length)
+        options.dom = bootstrapActive ? "<'row'<'col-sm-12'tr>>" : "t";
+      // alternatively lean things out for flexdashboard mobile portrait
+      else if (bootstrapActive && window.FlexDashboard && window.FlexDashboard.isMobilePhone())
+        options.dom = "<'row'<'col-sm-12'f>>" +
+                      "<'row'<'col-sm-12'tr>>"  +
+                      "<'row'<'col-sm-12'p>>";
     }
 
     $.extend(true, options, data.options || {});

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -98,7 +98,9 @@ it's containing element. If the table can't fit fully into it's container
 then vertical and/or horizontal scrolling of the table cells will occur.}
 
 \item{autoHideNavigation}{\code{TRUE} to automatically hide navigational UI
-when the number of total records is less than the page size.}
+(only display the table body) when the number of total records is less
+than the page size. Note, it only works on the client-side processing mode
+and the `pageLength` option should be provided explicitly.}
 
 \item{selection}{the row/column selection mode (single or multiple selection
 or disable selection) when a table widget is rendered in a Shiny app;

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -183,3 +183,12 @@ assert('clear message when options$search is illegal', {
   (inherits(out, 'try-error'))
   (grepl('must be NULL or a list', out[1L], fixed = TRUE))
 })
+
+assert('warn autoHideNavigation if no pageLength', {
+  (has_warning(
+    datatable(head(iris, 5), autoHideNavigation = TRUE)
+  ))
+  (!has_warning(
+    datatable(head(iris, 5), autoHideNavigation = TRUE, options = list(pageLength = 20))
+  ))
+})


### PR DESCRIPTION
Closes #856

### Content

1. `autoHideNavigation` now works with the default theme (previously, it only support the bootstrap theme)
1. The prerequisite (pageLength option + client-side mode) is properly documented
1. Throw warnings if pageLength option is not set or under server-side mode

### Example1

```r
DT::datatable(head(iris, 10), options = list(pageLength = 15), autoHideNavigation = TRUE)
```

### Example2

```r
library(shiny)
library(DT)
ui <- fluidPage(
  DTOutput("tbl")
)
server <- function(input, output) {
  output$tbl = renderDT({
    datatable(
      head(iris, 10),
      style = "bootstrap",
      autoHideNavigation = TRUE,
      options = list(pageLength = 20)
    )
  }, server = FALSE)
}
shiny::runApp(mget(c("ui", "server")))
```