### PR TITLE
Add support for shiny::bindCache()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,8 @@ Suggests:
     rmarkdown,
     shiny (>= 1.2.0),
     testit
+Remotes:
+    rstudio/shiny
 VignetteBuilder: knitr
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -182,15 +182,12 @@ renderDataTable = function(
     )
   }
 
-  # This snapshotPreprocessOutput function was added in shiny 1.0.3.9002
-  if (exists("snapshotPreprocessOutput", asNamespace("shiny"))) {
-    func = shiny::snapshotPreprocessOutput(func, function(value) {
-      # Looks for a string like this in the JSON:
-      # "url":"session/2a2b834d90637a7559f3ebaba460ad10/dataobj/table?w=&nonce=aea032f33aedfd0e",
-      # and removes it, so that the value isn't saved in test snapshots.
-      gsub('"ajax"\\s*:\\s*\\{\\s*"url"\\s*:\\s*"[^"]*"\\s*,?', '"ajax":{', value)
-    })
-  }
+  func = shiny::snapshotPreprocessOutput(func, function(value) {
+    # Looks for a string like this in the JSON:
+    # "url":"session/2a2b834d90637a7559f3ebaba460ad10/dataobj/table?w=&nonce=aea032f33aedfd0e",
+    # and removes it, so that the value isn't saved in test snapshots.
+    gsub('"ajax"\\s*:\\s*\\{\\s*"url"\\s*:\\s*"[^"]*"\\s*,?', '"ajax":{', value)
+  })
 
   shiny::registerInputHandler('DT.cellInfo', function(val, ...) {
     opts = options(stringsAsFactors = FALSE); on.exit(options(opts), add = TRUE)

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -44,7 +44,9 @@ renderDT(
 data is kept on the server and the browser requests a page at a time; if
 \code{FALSE}, then the entire data frame is sent to the browser at once.
 Highly recommended for medium to large data frames, which can cause
-browsers to slow down or crash.}
+browsers to slow down or crash. Note that if you want to use
+\code{renderDataTable} with \code{\link[shiny]{bindCache}()}, this must be
+\code{FALSE}.}
 
 \item{env}{The environment in which to evaluate \code{expr}.}
 


### PR DESCRIPTION
With this simple example app, the first user will see a delay before it shows the table, but other users who visit the app should see it instantly.

```
library(shiny)
library(DT)
shinyApp(
  ui = fluidPage(DTOutput('tbl')),
  server = function(input, output) {
    output$tbl <- renderDT({
        message("Computing...")
        Sys.sleep(2)
        iris
      }, 
      server = FALSE, 
      options = list(lengthChange = FALSE)
    ) %>%
      bindCache(1)
    
    # Note that bindCache() must be used with renderDT(server=FALSE)
  }
)
```