### PR TITLE
Don't overwrite responsive details/options if provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - The `autoHideNavigation` argument now works with the default theme. In addition, the prerequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
 
+- DT no longer overrides the `options$responsive` to `TRUE`. Thus, it enables users to provide customized options for the Responsive extension (thanks, @hdrab127, #885).
+
 # CHANGES IN DT VERSION 0.16
 
 ## NEW FEATURES

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -256,7 +256,7 @@ datatable = function(
   params$extensions = if (length(extensions)) as.list(extensions)
 
   # automatically configure options and callback for extensions
-  if ('Responsive' %in% extensions & is.null(options$responsive)) {
+  if ('Responsive' %in% extensions && is.null(options$responsive)) {
     options$responsive = TRUE
   }
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -256,7 +256,9 @@ datatable = function(
   params$extensions = if (length(extensions)) as.list(extensions)
 
   # automatically configure options and callback for extensions
-  if ('Responsive' %in% extensions) options$responsive = TRUE
+  if ('Responsive' %in% extensions & is.null(options$responsive)) {
+    options$responsive = TRUE
+  }
 
   params$caption = captionString(caption)
 


### PR DESCRIPTION
Tiny change to allow passing responsive options like child row control and others: https://datatables.net/extensions/responsive/examples/child-rows/right-column.html 

Previously these would be overwritten by defaults when `options$responsive` set to `TRUE`.

Thanks heaps!
Hayden