### PR TITLE
addRow() works for zero-row DT table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.16.3
+Version: 0.16.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 
 - The `autoHideNavigation` argument now works with the default theme. In addition, the prerequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
 
+## BUG FIXES
+
+- Fix the issue that `addRow()` would fail when the proxy DT table contains no data (e.g., a zero-row data.frame) (thanks, @chalioui, #888).
+
 # CHANGES IN DT VERSION 0.16
 
 ## NEW FEATURES

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1310,6 +1310,7 @@ HTMLWidgets.widget({
         data = rowname.concat(data)
       } else if (d !== 0) {
         console.log(data);
+        console.log(table.columns().indexes());
         throw 'New data must be of the same length as current data (' + n + ')';
       };
       table.row.add(data).draw(resetPaging);

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1305,12 +1305,11 @@ HTMLWidgets.widget({
     });
 
     methods.addRow = function(data, rowname, resetPaging) {
-      var data0 = table.row(0).data(), n = data0.length, d = n - data.length;
+      var n = table.columns().indexes().length, d = n - data.length;
       if (d === 1) {
         data = rowname.concat(data)
       } else if (d !== 0) {
         console.log(data);
-        console.log(data0);
         throw 'New data must be of the same length as current data (' + n + ')';
       };
       table.row.add(data).draw(resetPaging);


### PR DESCRIPTION
Fixes #888

Before the PR, the example code won't work for `init_data == "zero"` but ok for `init_data == "one"`.

After the PR, both cases would work fine.

```r
library(shiny)
zero_row_data <- data.frame(
  A = character(), B = character(),
  stringsAsFactors = FALSE
)
one_row_data <- data.frame(
  A = "A", B = "B",
  stringsAsFactors = FALSE
)
ui <- fluidPage(
  radioButtons("init_data", "initial data", c("zero", "one"), inline = TRUE),
  DT::DTOutput("tbl"), actionButton("add", "Add")
)
server <- function(input, output, session) {
  output$tbl <- DT::renderDT(
    server = FALSE,
    DT::datatable(if (input$init_data=="zero") zero_row_data else one_row_data)
  )
  proxy = DT::dataTableProxy(outputId = "tbl")
  observeEvent(
    input$add, {
      DT::addRow(proxy, one_row_data)
    }
  )
}
shiny::runApp(mget(c("ui", "server")))
```