### PR TITLE
editData() would update factor levels when necessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - The `autoHideNavigation` argument now works with the default theme. In addition, the prerequisite is properly documented. Specifically speaking, it only works when the `pageLength` option is provided and is rendered in the client-side processing mode (thanks, @bhogan-mitre, #856). 
 
+- When editing factor columns, `editData()` now automatically updates the factor levels if it's necessary (thanks, @aman-malik3010, #865).
+
 ## BUG FIXES
 
 - Fix the issue that `addRow()` would fail when the proxy DT table contains no data (e.g., a zero-row data.frame) (thanks, @chalioui, #888).

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,6 +116,8 @@ coerceValue = function(val, old) {
 #'   object created from \code{\link{dataTableProxy}()}, and the rest of
 #'   arguments are passed to \code{\link{replaceData}()} to update the data in a
 #'   DataTable instance in a Shiny app.
+#' @note For factor columns, new levels would be automatically added when necessary
+#'   to avoid \code{NA} coercing.
 #' @return The updated data object.
 #' @export
 editData = function(data, info, proxy = NULL, rownames = TRUE, resetPaging = FALSE, ...) {
@@ -126,6 +128,10 @@ editData = function(data, info, proxy = NULL, rownames = TRUE, resetPaging = FAL
     if (j == 0) {
       rownames(data)[i] = v
     } else {
+      # allow add new factor levels
+      if (is.factor(data[[j]]) && !all(v %in% levels(data[[j]]))) {
+        levels(data[[j]]) <- unique(c(levels(data[[j]]), v))
+      }
       data[i, j] = coerceValue(v, data[i, j, drop = TRUE])
     }
   }

--- a/man/editData.Rd
+++ b/man/editData.Rd
@@ -29,3 +29,7 @@ When editing cells in a DataTable in a Shiny app, we know the row/column
 indices and values of the cells that were edited. With these information, we
 can update the data object behind the DataTable accordingly.
 }
+\note{
+For factor columns, new levels would be automatically added when necessary
+  to avoid \code{NA} coercing.
+}


### PR DESCRIPTION
Fixes #865 

```r
library(shiny)
library(DT) 

tbl = data.frame(
  A = letters, B = LETTERS, stringsAsFactors = TRUE
)
ui = fluidPage(
  DTOutput("tbl")
)
server = function(input, output, session) {
  output$tbl = renderDT(tbl, editable = TRUE, rownames = TRUE)
  proxy = dataTableProxy('tbl')
  observeEvent(input$tbl_cell_edit, {
    info = input$tbl_cell_edit
    tbl <<- editData(tbl, info, proxy = proxy, resetPaging = FALSE, rownames = TRUE)
  })
}
shinyApp(ui = ui, server = server)
```

**NOTE, the data.frame's columns are factors**

## Before 

When editing table with new factor levels, DT displays the new value as NA, with a warning.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/8368933/103434781-07a87d80-4c41-11eb-9573-9160329f82b5.png">

<img width="979" alt="image" src="https://user-images.githubusercontent.com/8368933/103434784-11ca7c00-4c41-11eb-8afb-95066ecca1db.png">


## After

Now it displays as expected

<img width="828" alt="image" src="https://user-images.githubusercontent.com/8368933/103434772-e3e53780-4c40-11eb-80a0-249686d4ab35.png">

 