### PR TITLE
Don't use FlexDashboard.isFillPage() to override options client-side

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 - `datatable()`'s `style` argument now defaults to `'auto'`, which resolves to either `'bootstrap'` or `'bootstrap4'` when a `{bslib}` theme is relevant. If a `{bslib}` theme isn't relevant, `'auto'` resolves to the old default value of `'default'` (thanks, @cpsievert, #852).
 
+## BUG FIXES
+
+- `datatable(data)` and `datatable(data, fillContainer = TRUE)` now work as expected when statically rendered inside `flexdashboard::flex_dashboard()` (thanks, @cpsievert, #904).
+
+
 # CHANGES IN DT VERSION 0.17
 
 ## NEW FEATURES

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -134,16 +134,6 @@ HTMLWidgets.widget({
       instance.ctselectHandle.setGroup(crosstalkOptions.group);
     }
 
-    // If we are in a flexdashboard scroll layout then we:
-    //  (a) Always want to use pagination (otherwise we'll have
-    //      a "double scroll bar" effect on the phone); and
-    //  (b) Never want to fill the container (we want the pagination
-    //      level to determine the size of the container)
-    if (window.FlexDashboard && !window.FlexDashboard.isFillPage()) {
-      data.options.paging = true;
-      data.fillContainer = false;
-    }
-
     // if we are in the viewer then we always want to fillContainer and
     // and autoHideNavigation (unless the user has explicitly set these)
     if (window.HTMLWidgets.viewerMode) {


### PR DESCRIPTION
Closes #903

When statically rendered, DT's JS code executes before FlexDashboard has initialized, and so `isFillPage()` incorrectly returns false in that case. Also, `flexdashboard::flex_dashboard()` already sets the `options(DT.fillContainer = TRUE)` so this code seems unnecessary (it doesn't seem that the `paging = true` is needed either considering that [its the default in datatables.js](https://datatables.net/reference/option/paging)?)