### PR TITLE
Documentation for editData changed for parameter info

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -109,7 +109,7 @@ coerceValue = function(val, old) {
 #' @param data The original data object used in the DataTable.
 #' @param info The information about the edited cells. It should be obtained
 #'   from \code{input$tableId_cell_edit} from Shiny, and is a data frame
-#'   containing columns \code{row}, \code{column}, and \code{value}.
+#'   containing columns \code{row}, \code{col}, and \code{value}.
 #' @param rownames Whether row names are displayed in the table.
 #' @param proxy,resetPaging,... (Optional) If \code{proxy} is provided, it must
 #'   be either a character string of the output ID of the table or a proxy

--- a/man/editData.Rd
+++ b/man/editData.Rd
@@ -11,7 +11,7 @@ editData(data, info, proxy = NULL, rownames = TRUE, resetPaging = FALSE, ...)
 
 \item{info}{The information about the edited cells. It should be obtained
 from \code{input$tableId_cell_edit} from Shiny, and is a data frame
-containing columns \code{row}, \code{column}, and \code{value}.}
+containing columns \code{row}, \code{col}, and \code{value}.}
 
 \item{proxy, resetPaging, ...}{(Optional) If \code{proxy} is provided, it must
 be either a character string of the output ID of the table or a proxy


### PR DESCRIPTION
This PR adresses #941 issue.

For parameter `info` (in `editData()` function) documentation indicated that returning object is a `data.frame` with columns: `row`, `column`, `value`, but second name should be `col`. This is problematic for the user, because when she / he refers to `object$column` (instead of `object$col`), `NULL` is returned.