### PR TITLE
Allow string options$columnDefs$targets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.20.1
+Version: 0.20.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.21
 
+## MAJOR CHANGES
+
+- Now users can provide column names of the data to `options$columnDefs$targets`. Previously, it only supports column indexes or "_all" (thanks, @shrektan #948).
 
 # CHANGES IN DT VERSION 0.20
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -498,6 +498,10 @@ classNameDefinedColumns = function(options, ncol) {
   unique(cols)
 }
 
+targetIdx = function(targets, names, showRowName) {
+  unname(convertIdx(targets, names)) - !showRowName
+}
+
 colDefsTgtHandle = function(columnDefs, names, showRowName) {
   convert = function(targets, names, showRowName) {
     if (is.list(targets)) {
@@ -510,7 +514,7 @@ colDefsTgtHandle = function(columnDefs, names, showRowName) {
         targets = list(targets[is_all], targets[!is_all])
         out = lapply(targets, convert, names = names, showRowName = showRowName)
       } else {
-        out = unname(convertIdx(targets, names)) - !showRowName
+        out = targetIdx(targets, names, showRowName)
       }
       out
     } else {
@@ -522,7 +526,6 @@ colDefsTgtHandle = function(columnDefs, names, showRowName) {
     x
   })
 }
-
 
 # convert character indices to numeric
 convertIdx = function(i, names, n = length(names), invert = FALSE) {

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -509,12 +509,9 @@ colDefsTgtHandle = function(columnDefs, names) {
     if (is.list(targets)) {
       lapply(targets, convert, names = names)
     } else if (is.character(targets)) {
-      is_all = targets == "_all"
-      if (all(is_all)) {
+      any_all = "_all" %in% targets
+      if (any_all) {
         out = "_all"
-      } else if (any(is_all)) {
-        targets = list(targets[is_all], targets[!is_all])
-        out = lapply(targets, convert, names = names)
       } else {
         out = targetIdx(targets, names)
       }

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -149,11 +149,11 @@
 #'       \code{list(list(..., targets = '_all'), list(..., targets = c(1, 2)))}
 #'     \item \code{columnDefs$targets} is a vector and should be one of:
 #'       \itemize{
-#'         \item 0 or a positive integer: column index counting from the left
-#'         \item A negative integer: column index counting from the right
-#'         \item A string: the column name of the original data and not the ones that
-#'            could be changed via param \code{colnames}.
-#'         \item The string "_all": all columns (i.e. assign a default)
+#'         \item 0 or a positive integer: column index counting from the left.
+#'         \item A negative integer: column index counting from the right.
+#'         \item A string: the column name. Note, it must be the names of the
+#'           original data, not the ones that (could) be changed via param \code{colnames}.
+#'         \item The string "_all": all columns (i.e. assign a default).
 #'       }
 #'     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
 #'   }

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -155,6 +155,10 @@
 #'           original data, not the ones that (could) be changed via param \code{colnames}.
 #'         \item The string "_all": all columns (i.e. assign a default).
 #'       }
+#'     \item When conflicts happen, e.g., a single column is defined for some property
+#'       twice but with different values, the value that defined earlier takes the priority.
+#'       For example, \code{list(list(visible=FALSE, target=1), list(visible=TRUE, target=1))}
+#'       results in a table whose first column is \emph{invisible}.
 #'     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
 #'   }
 #' @note You are recommended to escape the table content for security reasons

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -225,11 +225,10 @@ datatable = function(
     data = cbind(' ' = rn, data)
     numc = numc + 1  # move indices of numeric columns to the right by 1
   }
-  cn = base::colnames(data)
-  # ===== data, rn, cn has been prepared ======== #
 
-  # convert the string targets
-  options[["columnDefs"]] = colDefsTgtHandle(options[["columnDefs"]], cn)
+  # convert the string targets; it must be defined here (not after), as it's supported to be
+  # applied to the "original" column names, instead of the "modified“ ones, e.g., via the `colnames` arg
+  options[["columnDefs"]] = colDefsTgtHandle(options[["columnDefs"]], base::colnames(data))
 
   # align numeric columns to the right
   if (length(numc)) {
@@ -248,6 +247,7 @@ datatable = function(
   # disable CSS classes for ordered columns
   if (is.null(options[['orderClasses']])) options$orderClasses = FALSE
 
+  cn = base::colnames(data)
   if (missing(colnames)) {
     colnames = cn
   } else if (!is.null(names(colnames))) {

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -520,7 +520,11 @@ colDefsTgtHandle = function(columnDefs, names) {
       targets
     }
   }
+  error_msg <- "options$columnDefs must be `NULL` or a list of list, where each of the internal list must contain a `targets` element."
   lapply(columnDefs, function(x) {
+    if (!is.list(x) || !"targets" %in% names(x)) {
+      stop(error_msg, call. = FALSE)
+    }
     x[["targets"]] = convert(x[["targets"]], names)
     x
   })

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -48,15 +48,10 @@ browsers to slow down or crash. Note that if you want to use
 \code{renderDataTable} with \code{shiny::bindCache()}, this must be
 \code{FALSE}.}
 
-\item{env}{The parent environment for the reactive expression. By default,
-this is the calling environment, the same as when defining an ordinary
-non-reactive expression. If \code{expr} is a quosure and \code{quoted} is \code{TRUE},
-then \code{env} is ignored.}
+\item{env}{The environment in which to evaluate \code{expr}.}
 
-\item{quoted}{If it is \code{TRUE}, then the \code{\link[=quote]{quote()}}ed value of \code{expr}
-will be used when \code{expr} is evaluated. If \code{expr} is a quosure and you
-would like to use its expression as a value for \code{expr}, then you must set
-\code{quoted} to \code{TRUE}.}
+\item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
+is useful if you want to save an expression in a variable.}
 
 \item{funcFilter}{(for expert use only) passed to the \code{filter} argument
 of \code{\link{dataTableAjax}()}}

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -48,10 +48,15 @@ browsers to slow down or crash. Note that if you want to use
 \code{renderDataTable} with \code{shiny::bindCache()}, this must be
 \code{FALSE}.}
 
-\item{env}{The environment in which to evaluate \code{expr}.}
+\item{env}{The parent environment for the reactive expression. By default,
+this is the calling environment, the same as when defining an ordinary
+non-reactive expression. If \code{expr} is a quosure and \code{quoted} is \code{TRUE},
+then \code{env} is ignored.}
 
-\item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
-is useful if you want to save an expression in a variable.}
+\item{quoted}{If it is \code{TRUE}, then the \code{\link[=quote]{quote()}}ed value of \code{expr}
+will be used when \code{expr} is evaluated. If \code{expr} is a quosure and you
+would like to use its expression as a value for \code{expr}, then you must set
+\code{quoted} to \code{TRUE}.}
 
 \item{funcFilter}{(for expert use only) passed to the \code{filter} argument
 of \code{\link{dataTableAjax}()}}

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -199,11 +199,11 @@ data frame) using the JavaScript library DataTables.
       \code{list(list(..., targets = '_all'), list(..., targets = c(1, 2)))}
     \item \code{columnDefs$targets} is a vector and should be one of:
       \itemize{
-        \item 0 or a positive integer: column index counting from the left
-        \item A negative integer: column index counting from the right
-        \item A string: the column name of the original data and not the ones that
-           could be changed via param \code{colnames}.
-        \item The string "_all": all columns (i.e. assign a default)
+        \item 0 or a positive integer: column index counting from the left.
+        \item A negative integer: column index counting from the right.
+        \item A string: the column name. Note, it must be the names of the
+          original data, not the ones that (could) be changed via param \code{colnames}.
+        \item The string "_all": all columns (i.e. assign a default).
       }
     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
   }

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -205,6 +205,10 @@ data frame) using the JavaScript library DataTables.
           original data, not the ones that (could) be changed via param \code{colnames}.
         \item The string "_all": all columns (i.e. assign a default).
       }
+    \item When conflicts happen, e.g., a single column is defined for some property
+      twice but with different values, the value that defined earlier takes the priority.
+      For example, \code{list(list(visible=FALSE, target=1), list(visible=TRUE, target=1))}
+      results in a table whose first column is \emph{invisible}.
     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
   }
 }

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -190,6 +190,23 @@ data frame) using the JavaScript library DataTables.
       server-side processing mode well. Please set this argument to
       \code{'none'} if you really want to use the Select extension.
   }
+  \code{options$columnDefs}:
+  \enumerate{
+    \item \code{columnDefs} is an option that provided by the DataTables library
+      itself, where the user can set various attributes for columns. It must be
+      provided as a list of list, where each sub-list must contain a vector named 'targets',
+      specifying the applied columns, i.e.,
+      \code{list(list(..., targets = '_all'), list(..., targets = c(1, 2)))}
+    \item \code{columnDefs$targets} is a vector and should be one of:
+      \itemize{
+        \item 0 or a positive integer: column index counting from the left
+        \item A negative integer: column index counting from the right
+        \item A string: the column name of the original data and not the ones that
+           could be changed via param \code{colnames}.
+        \item The string "_all": all columns (i.e. assign a default)
+      }
+    \item See \url{https://datatables.net/reference/option/columnDefs} for more.
+  }
 }
 \note{
 You are recommended to escape the table content for security reasons

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -196,8 +196,9 @@ assert('warn autoHideNavigation if no pageLength', {
 assert("colDefsTgtHandle() works", {
   cols = c("A", "B", "C")
   (colDefsTgtHandle(NULL, cols) %==% list())
-  (colDefsTgtHandle(NULL, cols) %==% list())
-
+  (colDefsTgtHandle(list(), cols) %==% list())
+  (has_error(colDefsTgtHandle("abc", cols)))
+  (has_error(colDefsTgtHandle(list("abc"), cols)))
   defs = list(
     list(1, targets = "_all"),
     list(2, targets = 1L),

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -206,17 +206,19 @@ assert("colDefsTgtHandle() works", {
     list(5, targets = list(c("A", "C"), "_all")),
     list(6, targets = list(1L, "_all")),
     list(7, targets = list(1L, "C")),
-    list(8, targets = list(1L, "B", "_all"))
+    list(8, targets = list(1L, "B", "_all")),
+    list(9, targets = list(1L, c("_all", "C")))
   )
   res = list(
     list(1, targets = "_all"),
     list(2, targets = 1L),
     list(3, targets = 1L),
-    list(4, targets = list("_all", 0L)),
+    list(4, targets = "_all"),
     list(5, targets = list(c(0L, 2L), "_all")),
     list(6, targets = list(1L, "_all")),
     list(7, targets = list(1L, 2L)),
-    list(8, targets = list(1L, 1L, "_all"))
+    list(8, targets = list(1L, 1L, "_all")),
+    list(9, targets = list(1L, "_all"))
   )
   (colDefsTgtHandle(defs, cols) %==% res)
 })

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -195,8 +195,8 @@ assert('warn autoHideNavigation if no pageLength', {
 
 assert("colDefsTgtHandle() works", {
   cols = c("A", "B", "C")
-  (colDefsTgtHandle(NULL, cols, TRUE) %==% list())
-  (colDefsTgtHandle(NULL, cols, FALSE) %==% list())
+  (colDefsTgtHandle(NULL, cols) %==% list())
+  (colDefsTgtHandle(NULL, cols) %==% list())
 
   defs = list(
     list(1, targets = "_all"),
@@ -208,17 +208,7 @@ assert("colDefsTgtHandle() works", {
     list(7, targets = list(1L, "C")),
     list(8, targets = list(1L, "B", "_all"))
   )
-  res1 = list(
-    list(1, targets = "_all"),
-    list(2, targets = 1L),
-    list(3, targets = 2L),
-    list(4, targets = list("_all", 1L)),
-    list(5, targets = list(c(1L, 3L), "_all")),
-    list(6, targets = list(1L, "_all")),
-    list(7, targets = list(1L, 3L)),
-    list(8, targets = list(1L, 2L, "_all"))
-  )
-  res2 = list(
+  res = list(
     list(1, targets = "_all"),
     list(2, targets = 1L),
     list(3, targets = 1L),
@@ -228,6 +218,5 @@ assert("colDefsTgtHandle() works", {
     list(7, targets = list(1L, 2L)),
     list(8, targets = list(1L, 1L, "_all"))
   )
-  (colDefsTgtHandle(defs, cols, TRUE) %==% res1)
-  (colDefsTgtHandle(defs, cols, FALSE) %==% res2)
+  (colDefsTgtHandle(defs, cols) %==% res)
 })

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -192,3 +192,42 @@ assert('warn autoHideNavigation if no pageLength', {
     datatable(head(iris, 5), autoHideNavigation = TRUE, options = list(pageLength = 20))
   ))
 })
+
+assert("colDefsTgtHandle() works", {
+  cols = c("A", "B", "C")
+  (colDefsTgtHandle(NULL, cols, TRUE) %==% list())
+  (colDefsTgtHandle(NULL, cols, FALSE) %==% list())
+
+  defs = list(
+    list(1, targets = "_all"),
+    list(2, targets = 1L),
+    list(3, targets = "B"),
+    list(4, targets = c("A", "_all")),
+    list(5, targets = list(c("A", "C"), "_all")),
+    list(6, targets = list(1L, "_all")),
+    list(7, targets = list(1L, "C")),
+    list(8, targets = list(1L, "B", "_all"))
+  )
+  res1 = list(
+    list(1, targets = "_all"),
+    list(2, targets = 1L),
+    list(3, targets = 2L),
+    list(4, targets = list("_all", 1L)),
+    list(5, targets = list(c(1L, 3L), "_all")),
+    list(6, targets = list(1L, "_all")),
+    list(7, targets = list(1L, 3L)),
+    list(8, targets = list(1L, 2L, "_all"))
+  )
+  res2 = list(
+    list(1, targets = "_all"),
+    list(2, targets = 1L),
+    list(3, targets = 1L),
+    list(4, targets = list("_all", 0L)),
+    list(5, targets = list(c(0L, 2L), "_all")),
+    list(6, targets = list(1L, "_all")),
+    list(7, targets = list(1L, 2L)),
+    list(8, targets = list(1L, 1L, "_all"))
+  )
+  (colDefsTgtHandle(defs, cols, TRUE) %==% res1)
+  (colDefsTgtHandle(defs, cols, FALSE) %==% res2)
+})


### PR DESCRIPTION
Due to implentation of DT, `options$columnDefs$targets` doesn't support string values (See #512). 

It's inconvinient as using column-names is always easier. In addition, it confuses the user in the first place, as it is inconsistent with DataTables' documentation.

This PR addresses this issue by converting the string valued `targets` into column index values of the data, internally.

### CODE

```r
x <- rnorm(10)
rk <- rank(x)
prefix <- sample(LETTERS[1:3], replace = TRUE, 10)
x_txt <- sprintf("%s%0.2f%%", prefix, x * 100)
tbl <- data.frame(V1 = x, V2 = x_txt, V3 = x, RK = rk)
DT::datatable(tbl, options = list(
  scrollY=FALSE, 
  columnDefs = list(
    list(visible = FALSE, targets = list("V3", 2))
  )
))
```

### Before the PR ("V3" is visible but it should not)

<img width="610" alt="image" src="https://user-images.githubusercontent.com/8368933/144718407-cf1b4e9e-c37b-44f6-bd6a-fe9dc358e712.png">


### After the PR ( "V3" is now invisible, as expected)

<img width="605" alt="image" src="https://user-images.githubusercontent.com/8368933/144718382-53f8e044-4b5b-4b3c-8cac-8f8799b103ef.png">


