### PR TITLE
Enabling R styling via a new param `formatter`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.20.1
+Version: 0.20.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.21
 
+## MAJOR CHANGES
+
+- Now users can provide column names of the data to `options$columnDefs$targets`. Previously, it only supports column indexes or "_all" (thanks, @shrektan #948).
 
 # CHANGES IN DT VERSION 0.20
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -262,6 +262,20 @@ datatable = function(
   # disable CSS classes for ordered columns
   if (is.null(options[['orderClasses']])) options$orderClasses = FALSE
 
+  data = applyFormatter(data, formatter)
+  format_cols = attr(data, "DT.format.cols", exact = TRUE)
+  raw_cols = attr(data, "DT.raw.cols", exact = TRUE)
+  if (length(format_cols)) options = appendColumnDefs(options, list(
+    visible = FALSE, targets = targetIdx(format_cols, base::colnames(data), showRowName = !is.null(rn))
+  ))
+  options$columnDefs = append(
+    options$columnDefs, colFormatter(
+      raw_cols, base::colnames(data), rownames = !is.null(rn), template = function(format_col_idx) {
+        sprintf("row[%d];", format_col_idx)
+      }, targetIdx(format_cols, base::colnames(data), showRowName = !is.null(rn))
+    ), after = 0L
+  )
+
   cn = base::colnames(data)
   if (missing(colnames)) {
     colnames = cn
@@ -603,7 +617,7 @@ applyFormatter = function(data, formatter) {
     toString(which(!is_fun))
   ), call. = FALSE)
   raw_cols = names(formatter)
-  format_cols = sprintf("_FORMAT_%s_", format_cols)
+  format_cols = sprintf("_FORMAT_%s_", raw_cols)
   col_exists = rep(TRUE, length(formatter))
   for (i in seq_along(formatter)) {
     raw_col = raw_cols[i]

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -595,6 +595,35 @@ sameSign = function(x, zero = 0L) {
   length(unique(as.vector(sign))) == 1L
 }
 
+applyFormatter = function(data, formatter) {
+  if (!length(formatter)) return(data)
+  is_fun = vapply(formatter, is.function, TRUE)
+  if (any(!is_fun)) stop(sprintf(
+    "The formatter values at indexes %s are not functions",
+    toString(which(!is_fun))
+  ), call. = FALSE)
+  format_cols = names(formatter)
+  raw_cols = sprintf("_RAW_%s_", format_cols)
+  col_exists = rep(TRUE, length(formatter))
+  for (i in seq_along(formatter)) {
+    format_col = format_cols[i]
+    if (!format_col %in% colnames(data)) {
+      col_exists[i] = FALSE
+      next
+    }
+    raw_col = raw_cols[i]
+    format_fun = formatter[[i]]
+    raw_value = data[[format_col]]
+    data[[raw_col]] = raw_value
+    data[[format_col]] = as.character(format_fun(raw_value))
+  }
+  raw_cols = raw_cols[col_exists]
+  format_cols = format_cols[col_exists]
+  attr(data, "DT.raw.cols") = raw_cols
+  attr(data, "DT.format.cols") = format_cols
+  data
+}
+
 #' Generate a table header or footer from column names
 #'
 #' Convenience functions to generate a table header (\samp{<thead></thead>}) or

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -164,14 +164,14 @@
 #'   \enumerate{
 #'     \item The formatting function must take a vector as input and return
 #'       a character vector (or can be converted into charactor vector via \code{as.character()})
-#'       and it will be applied on the column of data with the same name.
+#'       and it will be applied on the column of data with the same name. Unnamed or non-exists
+#'       values will be omited.
 #'     \item The value applied the function will be store into the column, without \bold{escaping}.
 #'       Thus, if it's intent to be escaped please escape the value via `htmltools::HTML()` in
 #'       the function body.
-#'     \item The raw value of the column will be renamed to "_RAW_{COLUMNNAME}_" internally.
-#'       This is used for data sorting and will be set to invisible automatically. Thus, we can
-#'       preserve the same order when sorting the columns, as if they're still in the raw value.
-#'     \item The default text-align of column will be decided by the raw value.
+#'     \item The formatted value of the column will be renamed to "_FORMAT_{COLUMNNAME}_" internally.
+#'       Thus, DataTables can read the formatted values when rendering. This will be set
+#'       to invisible automatically so that the users won't see them.
 #'   }
 #' @note You are recommended to escape the table content for security reasons
 #'   (e.g. XSS attacks) when using this function in Shiny or any other dynamic

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -637,10 +637,13 @@ applyFormatter = function(data, formatter, options) {
     format_fun = formatter[[i]]
     # so that the function can be applied recursively
     value = if (is.null(data[[format_col]])) data[[raw_col]] else data[[format_col]]
-    data[[format_col]] = as.character(format_fun(value))
+    data[[format_col]] = format_fun(value)
   }
-  raw_idx = targetIdx(raw_cols, base::colnames(data))
-  fmt_idx = targetIdx(format_cols, base::colnames(data))
+
+  # There probably be duplicated cols, but we only apply them for columnDefs once
+  unique_cols = unique(cbind(raw_cols, format_cols))
+  raw_idx = targetIdx(unique_cols[, 1], base::colnames(data))
+  fmt_idx = targetIdx(unique_cols[, 2], base::colnames(data))
   options = appendColumnDefs(options, list(
     visible = FALSE, targets = fmt_idx
   ))

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -107,10 +107,9 @@
 #'   columns and the text areas for some other columns by setting
 #'   \code{editable} to a list of the form \code{list(target = TARGET, numeric
 #'   = INDICES1, area = INDICES2)}.
-#' @param formatter should be a named list of formatting functions. The formatting
-#'   function will be applied on the column of data with the same name. The raw value
-#'   of the column will be renamed to "_ORDERDATA_{COLUMNNAME}_" internally and will
-#'   be used for data sorting.
+#' @param formatter should be a named list of formatting functions. Users can use
+#'   arbitrage R formatting function to style the DT columns. See details for more
+#'   information.
 #' @details \code{selection}:
 #'   \enumerate{
 #'     \item The argument could be a scalar string, which means the selection
@@ -160,6 +159,19 @@
 #'         \item The string "_all": all columns (i.e. assign a default).
 #'       }
 #'     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
+#'   }
+#'   \code{formatter}:
+#'   \enumerate{
+#'     \item The formatting function must take a vector as input and return
+#'       a character vector (or can be converted into charactor vector via \code{as.character()})
+#'       and it will be applied on the column of data with the same name.
+#'     \item The value applied the function will be store into the column, without \bold{escaping}.
+#'       Thus, if it's intent to be escaped please escape the value via `htmltools::HTML()` in
+#'       the function body.
+#'     \item The raw value of the column will be renamed to "_RAW_{COLUMNNAME}_" internally.
+#'       This is used for data sorting and will be set to invisible automatically. Thus, we can
+#'       preserve the same order when sorting the columns, as if they're still in the raw value.
+#'     \item The default text-align of column will be decided by the raw value.
 #'   }
 #' @note You are recommended to escape the table content for security reasons
 #'   (e.g. XSS attacks) when using this function in Shiny or any other dynamic

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -167,7 +167,7 @@
 #'       and it will be applied on the column of data with the same name. Unnamed or non-exists
 #'       values will be omited.
 #'     \item The value applied the function will be store into the column, without \bold{escaping}.
-#'       Thus, if it's intent to be escaped please escape the value via `htmltools::HTML()` in
+#'       Thus, if it's intent to be escaped please escape the value via `htmltools::htmlEscape()` in
 #'       the function body.
 #'     \item The formatted value of the column will be renamed to "_FORMAT_{COLUMNNAME}_" internally.
 #'       Thus, DataTables can read the formatted values when rendering. This will be set

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -149,11 +149,11 @@
 #'       \code{list(list(..., targets = '_all'), list(..., targets = c(1, 2)))}
 #'     \item \code{columnDefs$targets} is a vector and should be one of:
 #'       \itemize{
-#'         \item 0 or a positive integer: column index counting from the left
-#'         \item A negative integer: column index counting from the right
-#'         \item A string: the column name of the original data and not the ones that
-#'            could be changed via param \code{colnames}.
-#'         \item The string "_all": all columns (i.e. assign a default)
+#'         \item 0 or a positive integer: column index counting from the left.
+#'         \item A negative integer: column index counting from the right.
+#'         \item A string: the column name. Note, it must be the names of the
+#'           original data, not the ones that (could) be changed via param \code{colnames}.
+#'         \item The string "_all": all columns (i.e. assign a default).
 #'       }
 #'     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
 #'   }

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -644,6 +644,8 @@ applyFormatter = function(data, formatter, options) {
   unique_cols = unique(cbind(raw_cols, format_cols))
   raw_idx = targetIdx(unique_cols[, 1], base::colnames(data))
   fmt_idx = targetIdx(unique_cols[, 2], base::colnames(data))
+  # must convert into character explicilty so that functions like formattable::percent can work
+  data[, fmt_idx] = lapply(data[, fmt_idx, drop = FALSE], as.character)
   options = appendColumnDefs(options, list(
     visible = FALSE, targets = fmt_idx
   ))

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -241,6 +241,7 @@ datatable = function(
     data = cbind(' ' = rn, data)
     numc = numc + 1  # move indices of numeric columns to the right by 1
   }
+  escape = makeLogicalEscape(escape, base::colnames(data))
 
   # convert the string targets
   options[["columnDefs"]] = colDefsTgtHandle(options[["columnDefs"]], base::colnames(data))
@@ -266,6 +267,8 @@ datatable = function(
   fmt_idx = attr(data, "DT.format.idx", exact = TRUE)
   attr(data, "DT.format.idx") = NULL
   if (length(fmt_idx$raw)) {
+    # escape now a logical vector and we can append FALSE value after it
+    escape = c(escape, rep(FALSE, length(unique(fmt_idx$format))))
     options = appendColumnDefs(options, list(
       visible = FALSE, targets = fmt_idx$format
     ))
@@ -602,6 +605,17 @@ escapeToConfig = function(escape, colnames) {
   if (!is.numeric(escape)) escape = convertIdx(escape, colnames)
   if (is.logical(escape)) escape = which(escape)
   sprintf('"%s"', paste(escape, collapse = ','))
+}
+
+# `escape` can take many forms, making it difficult to process later, thus
+# we standardize it into a logical vector
+makeLogicalEscape = function(escape, colnames) {
+  out = rep(FALSE, length(colnames))
+  if (isTRUE(escape)) out[] = TRUE
+  if (isFALSE(escape)) { } # do nothing
+  if (!is.numeric(escape)) out[convertIdx(escape, colnames)] = TRUE
+  if (is.logical(escape)) out[which(escape)] = TRUE
+  out
 }
 
 sameSign = function(x, zero = 0L) {

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -107,6 +107,10 @@
 #'   columns and the text areas for some other columns by setting
 #'   \code{editable} to a list of the form \code{list(target = TARGET, numeric
 #'   = INDICES1, area = INDICES2)}.
+#' @param formatter should be a named list of formatting functions. The formatting
+#'   function will be applied on the column of data with the same name. The raw value
+#'   of the column will be renamed to "_ORDERDATA_{COLUMNNAME}_" internally and will
+#'   be used for data sorting.
 #' @details \code{selection}:
 #'   \enumerate{
 #'     \item The argument could be a scalar string, which means the selection
@@ -172,7 +176,7 @@ datatable = function(
   fillContainer = getOption('DT.fillContainer', NULL),
   autoHideNavigation = getOption('DT.autoHideNavigation', NULL),
   selection = c('multiple', 'single', 'none'), extensions = list(), plugins = NULL,
-  editable = FALSE
+  editable = FALSE, formatter = NULL
 ) {
 
   # yes, we all hate it

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -602,19 +602,18 @@ applyFormatter = function(data, formatter) {
     "The formatter values at indexes %s are not functions",
     toString(which(!is_fun))
   ), call. = FALSE)
-  format_cols = names(formatter)
-  raw_cols = sprintf("_RAW_%s_", format_cols)
+  raw_cols = names(formatter)
+  format_cols = sprintf("_FORMAT_%s_", format_cols)
   col_exists = rep(TRUE, length(formatter))
   for (i in seq_along(formatter)) {
-    format_col = format_cols[i]
-    if (!format_col %in% colnames(data)) {
+    raw_col = raw_cols[i]
+    if (!raw_col %in% colnames(data)) {
       col_exists[i] = FALSE
       next
     }
-    raw_col = raw_cols[i]
+    format_col = format_cols[i]
     format_fun = formatter[[i]]
-    raw_value = data[[format_col]]
-    data[[raw_col]] = raw_value
+    raw_value = data[[raw_col]]
     data[[format_col]] = as.character(format_fun(raw_value))
   }
   raw_cols = raw_cols[col_exists]

--- a/R/format.R
+++ b/R/format.R
@@ -290,7 +290,7 @@ jsValues = function(x) {
   } else if (inherits(x, "Date")) {
     x = format(x, "%Y-%m-%d")
   }
-  vapply(x, jsonlite::toJSON, character(1), auto_unbox = TRUE)
+  vapply(x, jsonlite::toJSON, character(1), auto_unbox = TRUE, USE.NAMES = FALSE)
 }
 
 

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -48,15 +48,10 @@ browsers to slow down or crash. Note that if you want to use
 \code{renderDataTable} with \code{shiny::bindCache()}, this must be
 \code{FALSE}.}
 
-\item{env}{The parent environment for the reactive expression. By default,
-this is the calling environment, the same as when defining an ordinary
-non-reactive expression. If \code{expr} is a quosure and \code{quoted} is \code{TRUE},
-then \code{env} is ignored.}
+\item{env}{The environment in which to evaluate \code{expr}.}
 
-\item{quoted}{If it is \code{TRUE}, then the \code{\link[=quote]{quote()}}ed value of \code{expr}
-will be used when \code{expr} is evaluated. If \code{expr} is a quosure and you
-would like to use its expression as a value for \code{expr}, then you must set
-\code{quoted} to \code{TRUE}.}
+\item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
+is useful if you want to save an expression in a variable.}
 
 \item{funcFilter}{(for expert use only) passed to the \code{filter} argument
 of \code{\link{dataTableAjax}()}}

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -199,11 +199,11 @@ data frame) using the JavaScript library DataTables.
       \code{list(list(..., targets = '_all'), list(..., targets = c(1, 2)))}
     \item \code{columnDefs$targets} is a vector and should be one of:
       \itemize{
-        \item 0 or a positive integer: column index counting from the left
-        \item A negative integer: column index counting from the right
-        \item A string: the column name of the original data and not the ones that
-           could be changed via param \code{colnames}.
-        \item The string "_all": all columns (i.e. assign a default)
+        \item 0 or a positive integer: column index counting from the left.
+        \item A negative integer: column index counting from the right.
+        \item A string: the column name. Note, it must be the names of the
+          original data, not the ones that (could) be changed via param \code{colnames}.
+        \item The string "_all": all columns (i.e. assign a default).
       }
     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
   }

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -216,14 +216,14 @@ data frame) using the JavaScript library DataTables.
   \enumerate{
     \item The formatting function must take a vector as input and return
       a character vector (or can be converted into charactor vector via \code{as.character()})
-      and it will be applied on the column of data with the same name.
+      and it will be applied on the column of data with the same name. Unnamed or non-exists
+      values will be omited.
     \item The value applied the function will be store into the column, without \bold{escaping}.
       Thus, if it's intent to be escaped please escape the value via `htmltools::HTML()` in
       the function body.
-    \item The raw value of the column will be renamed to "_RAW_{COLUMNNAME}_" internally.
-      This is used for data sorting and will be set to invisible automatically. Thus, we can
-      preserve the same order when sorting the columns, as if they're still in the raw value.
-    \item The default text-align of column will be decided by the raw value.
+    \item The formatted value of the column will be renamed to "_FORMAT_{COLUMNNAME}_" internally.
+      Thus, DataTables can read the formatted values when rendering. This will be set
+      to invisible automatically so that the users won't see them.
   }
 }
 \note{

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -219,7 +219,7 @@ data frame) using the JavaScript library DataTables.
       and it will be applied on the column of data with the same name. Unnamed or non-exists
       values will be omited.
     \item The value applied the function will be store into the column, without \bold{escaping}.
-      Thus, if it's intent to be escaped please escape the value via `htmltools::HTML()` in
+      Thus, if it's intent to be escaped please escape the value via `htmltools::htmlEscape()` in
       the function body.
     \item The formatted value of the column will be renamed to "_FORMAT_{COLUMNNAME}_" internally.
       Thus, DataTables can read the formatted values when rendering. This will be set

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -190,6 +190,23 @@ data frame) using the JavaScript library DataTables.
       server-side processing mode well. Please set this argument to
       \code{'none'} if you really want to use the Select extension.
   }
+  \code{options$columnDefs}:
+  \enumerate{
+    \item \code{columnDefs} is an option that provided by the DataTables library
+      itself, where the user can set various attributes for columns. It must be
+      provided as a list of list, where each sub-list must contain a vector named 'targets',
+      specifying the applied columns, i.e.,
+      \code{list(list(..., targets = '_all'), list(..., targets = c(1, 2)))}
+    \item \code{columnDefs$targets} is a vector and should be one of:
+      \itemize{
+        \item 0 or a positive integer: column index counting from the left
+        \item A negative integer: column index counting from the right
+        \item A string: the column name of the original data and not the ones that
+           could be changed via param \code{colnames}.
+        \item The string "_all": all columns (i.e. assign a default)
+      }
+    \item See \url{https://datatables.net/reference/option/columnDefs} for more.
+  }
 }
 \note{
 You are recommended to escape the table content for security reasons

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -24,7 +24,8 @@ datatable(
   selection = c("multiple", "single", "none"),
   extensions = list(),
   plugins = NULL,
-  editable = FALSE
+  editable = FALSE,
+  formatter = NULL
 )
 }
 \arguments{
@@ -151,6 +152,10 @@ all columns. Of course, you can request the numeric editing for some
 columns and the text areas for some other columns by setting
 \code{editable} to a list of the form \code{list(target = TARGET, numeric
 = INDICES1, area = INDICES2)}.}
+
+\item{formatter}{should be a named list of formatting functions. Users can use
+arbitrage R formatting function to style the DT columns. See details for more
+information.}
 }
 \description{
 This function creates an HTML widget to display rectangular data (a matrix or
@@ -206,6 +211,19 @@ data frame) using the JavaScript library DataTables.
         \item The string "_all": all columns (i.e. assign a default).
       }
     \item See \url{https://datatables.net/reference/option/columnDefs} for more.
+  }
+  \code{formatter}:
+  \enumerate{
+    \item The formatting function must take a vector as input and return
+      a character vector (or can be converted into charactor vector via \code{as.character()})
+      and it will be applied on the column of data with the same name.
+    \item The value applied the function will be store into the column, without \bold{escaping}.
+      Thus, if it's intent to be escaped please escape the value via `htmltools::HTML()` in
+      the function body.
+    \item The raw value of the column will be renamed to "_RAW_{COLUMNNAME}_" internally.
+      This is used for data sorting and will be set to invisible automatically. Thus, we can
+      preserve the same order when sorting the columns, as if they're still in the raw value.
+    \item The default text-align of column will be decided by the raw value.
   }
 }
 \note{

--- a/tests/testit/test-datatables.R
+++ b/tests/testit/test-datatables.R
@@ -192,3 +192,42 @@ assert('warn autoHideNavigation if no pageLength', {
     datatable(head(iris, 5), autoHideNavigation = TRUE, options = list(pageLength = 20))
   ))
 })
+
+assert("colDefsTgtHandle() works", {
+  cols = c("A", "B", "C")
+  (colDefsTgtHandle(NULL, cols, TRUE) %==% list())
+  (colDefsTgtHandle(NULL, cols, FALSE) %==% list())
+
+  defs = list(
+    list(1, targets = "_all"),
+    list(2, targets = 1L),
+    list(3, targets = "B"),
+    list(4, targets = c("A", "_all")),
+    list(5, targets = list(c("A", "C"), "_all")),
+    list(6, targets = list(1L, "_all")),
+    list(7, targets = list(1L, "C")),
+    list(8, targets = list(1L, "B", "_all"))
+  )
+  res1 = list(
+    list(1, targets = "_all"),
+    list(2, targets = 1L),
+    list(3, targets = 2L),
+    list(4, targets = list("_all", 1L)),
+    list(5, targets = list(c(1L, 3L), "_all")),
+    list(6, targets = list(1L, "_all")),
+    list(7, targets = list(1L, 3L)),
+    list(8, targets = list(1L, 2L, "_all"))
+  )
+  res2 = list(
+    list(1, targets = "_all"),
+    list(2, targets = 1L),
+    list(3, targets = 1L),
+    list(4, targets = list("_all", 0L)),
+    list(5, targets = list(c(0L, 2L), "_all")),
+    list(6, targets = list(1L, "_all")),
+    list(7, targets = list(1L, 2L)),
+    list(8, targets = list(1L, 1L, "_all"))
+  )
+  (colDefsTgtHandle(defs, cols, TRUE) %==% res1)
+  (colDefsTgtHandle(defs, cols, FALSE) %==% res2)
+})


### PR DESCRIPTION
Closes #938 #652 

DT implements many nice JS wrappers on styling the columns. However, R users may still find they want to implement their own style, as the love for beautiful table never ends.  They can do it in two ways:

1. On JS side: Write a JS function and set it in `render` options, i.e., `datatable(..., options = list( columnDefs = list( list(targets = 1, render = JS(...)))))`
2. On R side: Transform the R data.frame object's relevent column into characters, then pass it to DT, probably need to set the `escape` argument to `FALSE`.

Unfortunately, those two methods are either difficult to implement or contain side-effects:

1. JS method: 
  - Many R users are not aware of the existence of the `columnDefs.render` option
  - Write the JS function correctly is not easy, especially when the "style" is complicated
  - You can't leverage the existing R packages like `formattable`
2. R method:
  - Probably lose the ability to sort, filter or search correctly as the raw "data" is tranformed into formatted "data"
  - Probably need additional efforts to "unescape" data, align text, etc.

The new param `formatter` allows users to write formatting functions in R without losing the ability to sort, filter or search by  retaining the raw data "untouched" by creating invisible helper columns.

## NOTE

This PR depends on PR #948 

## TODO

- [ ] support formatter type like `list(function() ... , targets = ...)`
- [ ] figure out a way when the formatter need other info from the data, like other column
- [ ] try out all the possible corner cases in case of unexpected happening
- [ ] state clear the limitations in doc (probably cause issues when editing data
- [ ] need to triger updating the hidden formatted columns when source is updated, e.g, via proxy, or editing
- [ ] NEWS 
- [ ] Add an example into inst/example
- [ ] Add an example into site
- [ ] add tests


## Example

```r
set.seed(100)
x <- rnorm(10)
rk <- rank(x)
prefix <- sample(LETTERS[1:3], replace = TRUE, 10)
tbl <- data.frame(V1 = x, V2 = x, V3 = x, V4 = x, RK = rk)
DT::datatable(tbl, rownames = FALSE, filter = "top", formatter = list(
  V2 = function(x) paste0(prefix, round(x * 100, 2), "%"),
  V3 = formattable::percent,
  V4 = function(x) round(x * 100, 2),
  V4 = formattable::color_tile(min.color = "yellow", max.color = "red")
))
```
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/8368933/144744072-312cb1ec-7657-444a-b093-2e2d88faba59.png">


