### PR TITLE
add zero.print to formatXXX functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.20.1
+Version: 0.20.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN DT VERSION 0.21
 
+## NEW FEATURES
+
+- Add the `zero.print` argument to `formatPercentage()`, `formatCurrency()`, `formatSignif()` and `formatRound()`, which allows to control the format of zero values. It's useful when the data is "sparse" (thanks, @shrektan #953).
 
 # CHANGES IN DT VERSION 0.20
 

--- a/R/format.R
+++ b/R/format.R
@@ -293,6 +293,14 @@ jsValues = function(x) {
   vapply(x, jsonlite::toJSON, character(1), auto_unbox = TRUE)
 }
 
+jsValuesHandleNull = function(x) {
+  if (is.null(x)) {
+    "null"
+  } else {
+    jsValues(x)
+  }
+}
+
 
 #' Conditional CSS styles
 #'

--- a/R/format.R
+++ b/R/format.R
@@ -376,7 +376,7 @@ styleEqual = function(levels, values, default = NULL) {
   # set the css to null will leave the attribute as it is. Despite it's not
   # documented explicitly but the jquery test covers this behavior
   # https://github.com/jquery/jquery/commit/2ae872c594790c4b935a1d7eabdf8b8212fd3c3f
-  default = if (is.null(default)) 'null' else jsValues(default)
+  default = jsValuesHandleNull(default)
   JS(paste0(js, default))
 }
 
@@ -425,6 +425,6 @@ styleRow = function(rows, values, default = NULL) {
     # must use dataIndex + 1 as it's suppse
     js = paste0(js, sprintf("$.inArray(dataIndex + 1, [%s]) >= 0 ? %s : ", toString(row), values[i]))
   }
-  default = if (is.null(default)) 'null' else jsValues(default)
+  default = jsValuesHandleNull(default)
   JS(paste0(js, default))
 }

--- a/R/format.R
+++ b/R/format.R
@@ -39,6 +39,8 @@ formatColumns = function(table, columns, template, ..., appendTo = c('columnDefs
 #' @param mark the marker after every \code{interval} decimals in the numbers
 #' @param dec.mark a character to indicate the decimal point
 #' @param before whether to place the currency symbol before or after the values
+#' @param zero.print a string to specify how zeros should be formatted.
+#'   Useful for when many zero values exist. If \code{NULL}, keeps zero as it is.
 #' @references See \url{https://rstudio.github.io/DT/functions.html} for detailed
 #'   documentation and examples.
 #' @note The length of arguments other than \code{table} should be 1 or the same as
@@ -68,11 +70,11 @@ formatColumns = function(table, columns, template, ..., appendTo = c('columnDefs
 #'   )
 formatCurrency = function(
   table, columns, currency = '$', interval = 3, mark = ',', digits = 2,
-  dec.mark = getOption('OutDec'), before = TRUE
+  dec.mark = getOption('OutDec'), before = TRUE, zero.print = NULL
 ) {
   currency = gsub("'", "\\\\'", currency)
   mark = gsub("'", "\\\\'", mark)
-  formatColumns(table, columns, tplCurrency, currency, interval, mark, digits, dec.mark, before)
+  formatColumns(table, columns, tplCurrency, currency, interval, mark, digits, dec.mark, before, zero.print)
 }
 
 #' @export
@@ -87,25 +89,25 @@ formatString = function(table, columns, prefix = '', suffix = '') {
 #' @rdname formatCurrency
 #' @param digits the number of decimal places to round to
 formatPercentage = function(
-  table, columns, digits = 0, interval = 3, mark = ',', dec.mark = getOption('OutDec')
+  table, columns, digits = 0, interval = 3, mark = ',', dec.mark = getOption('OutDec'), zero.print = NULL
 ) {
-  formatColumns(table, columns, tplPercentage, digits, interval, mark, dec.mark)
+  formatColumns(table, columns, tplPercentage, digits, interval, mark, dec.mark, zero.print)
 }
 
 #' @export
 #' @rdname formatCurrency
 formatRound = function(
-  table, columns, digits = 2, interval = 3, mark = ',', dec.mark = getOption('OutDec')
+  table, columns, digits = 2, interval = 3, mark = ',', dec.mark = getOption('OutDec'), zero.print = NULL
 ) {
-  formatColumns(table, columns, tplRound, digits, interval, mark, dec.mark)
+  formatColumns(table, columns, tplRound, digits, interval, mark, dec.mark, zero.print)
 }
 
 #' @export
 #' @rdname formatCurrency
 formatSignif = function(
-  table, columns, digits = 2, interval = 3, mark = ',', dec.mark = getOption('OutDec')
+  table, columns, digits = 2, interval = 3, mark = ',', dec.mark = getOption('OutDec'), zero.print = NULL
 ) {
-  formatColumns(table, columns, tplSignif, digits, interval, mark, dec.mark)
+  formatColumns(table, columns, tplSignif, digits, interval, mark, dec.mark, zero.print)
 }
 
 #' @export
@@ -212,11 +214,11 @@ appendFormatter = function(js, name, names, rownames = TRUE, template, ...) {
   ))
 }
 
-tplCurrency = function(currency, interval, mark, digits, dec.mark, before, ...) {
+tplCurrency = function(currency, interval, mark, digits, dec.mark, before, zero.print, ...) {
   sprintf(
-    "DTWidget.formatCurrency(data, %s, %d, %d, %s, %s, %s);",
+    "DTWidget.formatCurrency(data, %s, %d, %d, %s, %s, %s, %s);",
     jsValues(currency), digits, interval, jsValues(mark), jsValues(dec.mark),
-    jsValues(before)
+    jsValues(before), jsValuesHandleNull(zero.print)
   )
 }
 
@@ -227,24 +229,24 @@ tplString = function(prefix, suffix, ...) {
   )
 }
 
-tplPercentage = function(digits, interval, mark, dec.mark, ...) {
+tplPercentage = function(digits, interval, mark, dec.mark, zero.print, ...) {
   sprintf(
-    "DTWidget.formatPercentage(data, %d, %d, %s, %s);",
-    digits, interval, jsValues(mark), jsValues(dec.mark)
+    "DTWidget.formatPercentage(data, %d, %d, %s, %s, %s);",
+    digits, interval, jsValues(mark), jsValues(dec.mark), jsValuesHandleNull(zero.print)
   )
 }
 
-tplRound = function(digits, interval, mark, dec.mark, ...) {
+tplRound = function(digits, interval, mark, dec.mark, zero.print, ...) {
   sprintf(
-    "DTWidget.formatRound(data, %d, %d, %s, %s);",
-    digits, interval, jsValues(mark), jsValues(dec.mark)
+    "DTWidget.formatRound(data, %d, %d, %s, %s, %s);",
+    digits, interval, jsValues(mark), jsValues(dec.mark), jsValuesHandleNull(zero.print)
   )
 }
 
-tplSignif = function(digits, interval, mark, dec.mark, ...) {
+tplSignif = function(digits, interval, mark, dec.mark, zero.print, ...) {
   sprintf(
-    "DTWidget.formatSignif(data, %d, %d, %s, %s);",
-    digits, interval, jsValues(mark), jsValues(dec.mark)
+    "DTWidget.formatSignif(data, %d, %d, %s, %s, %s);",
+    digits, interval, jsValues(mark), jsValues(dec.mark), jsValuesHandleNull(zero.print)
   )
 }
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -17,9 +17,10 @@ var markInterval = function(d, digits, interval, mark, decMark, precision) {
   return xv.join(decMark);
 };
 
-DTWidget.formatCurrency = function(data, currency, digits, interval, mark, decMark, before) {
+DTWidget.formatCurrency = function(data, currency, digits, interval, mark, decMark, before, zeroPrint) {
   var d = parseFloat(data);
   if (isNaN(d)) return '';
+  if (zeroPrint !== null && d === 0.0) return zeroPrint;
   var res = markInterval(d, digits, interval, mark, decMark);
   res = before ? (/^-/.test(res) ? '-' + currency + res.replace(/^-/, '') : currency + res) :
     res + currency;
@@ -32,21 +33,24 @@ DTWidget.formatString = function(data, prefix, suffix) {
   return prefix + d + suffix;
 };
 
-DTWidget.formatPercentage = function(data, digits, interval, mark, decMark) {
+DTWidget.formatPercentage = function(data, digits, interval, mark, decMark, zeroPrint) {
   var d = parseFloat(data);
   if (isNaN(d)) return '';
+  if (zeroPrint !== null && d === 0.0) return zeroPrint;
   return markInterval(d * 100, digits, interval, mark, decMark) + '%';
 };
 
-DTWidget.formatRound = function(data, digits, interval, mark, decMark) {
+DTWidget.formatRound = function(data, digits, interval, mark, decMark, zeroPrint) {
   var d = parseFloat(data);
   if (isNaN(d)) return '';
+  if (zeroPrint !== null && d === 0.0) return zeroPrint;
   return markInterval(d, digits, interval, mark, decMark);
 };
 
-DTWidget.formatSignif = function(data, digits, interval, mark, decMark) {
+DTWidget.formatSignif = function(data, digits, interval, mark, decMark, zeroPrint) {
   var d = parseFloat(data);
   if (isNaN(d)) return '';
+  if (zeroPrint !== null && d === 0.0) return zeroPrint;
   return markInterval(d, digits, interval, mark, decMark, true);
 };
 

--- a/man/formatCurrency.Rd
+++ b/man/formatCurrency.Rd
@@ -18,7 +18,8 @@ formatCurrency(
   mark = ",",
   digits = 2,
   dec.mark = getOption("OutDec"),
-  before = TRUE
+  before = TRUE,
+  zero.print = NULL
 )
 
 formatString(table, columns, prefix = "", suffix = "")
@@ -29,7 +30,8 @@ formatPercentage(
   digits = 0,
   interval = 3,
   mark = ",",
-  dec.mark = getOption("OutDec")
+  dec.mark = getOption("OutDec"),
+  zero.print = NULL
 )
 
 formatRound(
@@ -38,7 +40,8 @@ formatRound(
   digits = 2,
   interval = 3,
   mark = ",",
-  dec.mark = getOption("OutDec")
+  dec.mark = getOption("OutDec"),
+  zero.print = NULL
 )
 
 formatSignif(
@@ -47,7 +50,8 @@ formatSignif(
   digits = 2,
   interval = 3,
   mark = ",",
-  dec.mark = getOption("OutDec")
+  dec.mark = getOption("OutDec"),
+  zero.print = NULL
 )
 
 formatDate(table, columns, method = "toDateString", params = NULL)
@@ -82,6 +86,9 @@ equivalent to \code{c('V1', 'V2')})}
 \item{dec.mark}{a character to indicate the decimal point}
 
 \item{before}{whether to place the currency symbol before or after the values}
+
+\item{zero.print}{a string to specify how zeros should be formatted.
+Useful for when many zero values exist. If \code{NULL}, keeps zero as it is.}
 
 \item{prefix}{string to put in front of the column values}
 

--- a/tests/testit/test-format.R
+++ b/tests/testit/test-format.R
@@ -90,3 +90,9 @@ assert('styleRow works', {
   (out$x$options$rowCallback %==% expect)
 })
 
+assert('jsValuesHandleNull works', {
+  (jsValuesHandleNull(NULL) %==% 'null')
+  (jsValuesHandleNull(123) %==% '123')
+  (jsValuesHandleNull('abc') %==% jsValues('abc'))
+})
+


### PR DESCRIPTION
Closes #953 

```r
set.seed(1106)
sample_data <- cbind(PCT = rnorm(10), CRY = rnorm(10) * 10000, SIG = rnorm(10) * 10000, RND = rnorm(10) * 10000)
sample_data <- rbind(0, sample_data)

htmltools::browsable(htmltools::withTags(htmltools::tagList(
  h1("With zero.print"),
  hr(),
  DT::datatable(sample_data, selection = "none") |> 
    formatPercentage("PCT", zero.print = "-") |>
    formatCurrency("CRY", zero.print = "$$$$$$") |>
    formatSignif("SIG", zero.print = "000e0000") |>
    formatRound("RND", zero.print = "0000.000"),
  h1("Without zero.print"),
  hr(),
  DT::datatable(sample_data, selection = "none") |> 
    formatPercentage("PCT") |>
    formatCurrency("CRY") |>
    formatSignif("SIG") |>
    formatRound("RND")
)))
```

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/8368933/150367255-6166a0bd-96df-4ad1-8240-359b9c041911.png">

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/8368933/150367300-f1d64c1f-8ed2-4921-945b-45d2ea6eed91.png">
