### PR TITLE
repeat the scalar values argument in `styleRow()` and `styleEqual()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.20.2
+Version: 0.20.3
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Add the `zero.print` argument to `formatPercentage()`, `formatCurrency()`, `formatSignif()` and `formatRound()`, which allows to control the format of zero values. It's useful when the data is "sparse" (thanks, @shrektan #953).
 
+## MINOR CHANGES
+
+- `styleRow()` and `styleEqual()` now allows a scalar `values` argument like other R functions, e.g., `styleRow(1:5, 'abcd')` is the same as `styleRow(1:5, rep('abcd', 5))`. It throws error that `the length(rows) must be equal to length(values)` in the previous version (thanks, @shrektan #955).
+
 # CHANGES IN DT VERSION 0.20
 
 ## MAJOR CHANGES

--- a/R/format.R
+++ b/R/format.R
@@ -360,8 +360,9 @@ styleInterval = function(cuts, values) {
 #' @rdname styleInterval
 styleEqual = function(levels, values, default = NULL) {
   n = length(levels)
+  if (length(values) == 1L) values <- rep(values, n)
   if (n != length(values))
-    stop("length(levels) must be equal to length(values)")
+    stop("length(levels) must be equal to length(values) when `values` is not a scalar")
   if (!is.null(default) && (!is.character(default) || length(default) != 1))
     stop("default must be null or a string")
   if (n == 0) return("''")
@@ -410,13 +411,14 @@ styleColorBar = function(data, color, angle=90) {
 
 #' @param rows the Row Indexes (starting from 1) that applies the CSS style. It could
 #' be an integer vector or a list of integer vectors, whose length must be equal to
-#' the length of \code{values}.
+#' the length of \code{values}, when \code{values} is not a scalar.
 #' @rdname styleInterval
 #' @export
 styleRow = function(rows, values, default = NULL) {
   n = length(rows)
+  if (length(values) == 1L) values <- rep(values, n)
   if (n != length(values))
-    stop("length(rows) must be equal to length(values)")
+    stop("length(rows) must be equal to length(values) when `values` is not a scalar")
   if (!is.null(default) && (!is.character(default) || length(default) != 1))
     stop("default must be null or a string")
   if (n == 0) return("''")

--- a/man/styleInterval.Rd
+++ b/man/styleInterval.Rd
@@ -44,7 +44,7 @@ left to right.}
 
 \item{rows}{the Row Indexes (starting from 1) that applies the CSS style. It could
 be an integer vector or a list of integer vectors, whose length must be equal to
-the length of \code{values}.}
+the length of \code{values}, when \code{values} is not a scalar.}
 }
 \description{
 A few helper functions for the \code{\link{formatStyle}()} function to

--- a/tests/testit/test-format.R
+++ b/tests/testit/test-format.R
@@ -96,3 +96,12 @@ assert('jsValuesHandleNull works', {
   (jsValuesHandleNull('abc') %==% jsValues('abc'))
 })
 
+assert('styleRow and styleEqual allows scalar values', {
+  result = styleRow(1:2, 'a')
+  expect = JS("$.inArray(dataIndex + 1, [1]) >= 0 ? \"a\" : $.inArray(dataIndex + 1, [2]) >= 0 ? \"a\" : null")
+  (result %==% expect)
+  result = styleEqual(1:2, 'a')
+  expect = JS("value == 1 ? \"a\" : value == 2 ? \"a\" : null")
+  (result %==% expect)
+})
+


### PR DESCRIPTION
Closes #955 


```r
DT::datatable(
  data.frame(A = letters, B = LETTERS)
) |> 
  DT::formatStyle("A", backgroundColor = styleRow(2:4, "pink")) |>
  DT::formatStyle("B", backgroundColor = styleEqual(c("C", "D"), "lightblue"))
```

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/8368933/150705316-fd0bbb32-dd5b-453f-a4fb-7f28b2c84ae6.png">
