### PR TITLE
fix addRow's support on a list of data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.20.3
+Version: 0.20.4
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 # CHANGES IN DT VERSION 0.21
 
-## MAJOR CHANGES
-
-- Now users can provide column names of the data to `options$columnDefs$targets`. Previously, it only supports column indexes or "_all" (thanks, @shrektan #948).
-
 ## NEW FEATURES
 
 - Add the `zero.print` argument to `formatPercentage()`, `formatCurrency()`, `formatSignif()` and `formatRound()`, which allows to control the format of zero values. It's useful when the data is "sparse" (thanks, @shrektan #953).
+
+## MAJOR CHANGES
+
+- Now users can provide column names of the data to `options$columnDefs$targets`. Previously, it only supports column indexes or "_all" (thanks, @shrektan #948).
 
 ## MINOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
 
 - `styleRow()` and `styleEqual()` now allows a scalar `values` argument like other R functions, e.g., `styleRow(1:5, 'abcd')` is the same as `styleRow(1:5, rep('abcd', 5))`. It throws error that `the length(rows) must be equal to length(values)` in the previous version (thanks, @shrektan #955).
 
+## BUG FIXES
+
+- Fix the bug that `addRow()` doesn't support a list of `data` after R 3.4.0, where `structure(NULL, ...)` was deprecated (thanks, @stla @shrektan #959).
+
 # CHANGES IN DT VERSION 0.20
 
 ## MAJOR CHANGES

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -341,10 +341,11 @@ selectCells = function(proxy, selected, ignore.selectable = FALSE) {
 addRow = function(proxy, data, resetPaging = TRUE) {
   if ((is.matrix(data) || is.data.frame(data)) && nrow(data) != 1)
     stop("'data' must be of only one row")
+  rn <- rownames(data); if (!is.null(rn)) rn <- I(rn)
   # must apply unname() after as.list() because a data.table object
   # can't be really unnamed. The names() attributes will be
   # preserved but with empty strings (see #760).
-  invokeRemote(proxy, 'addRow', list(unname(as.list(data)), I(rownames(data)), resetPaging))
+  invokeRemote(proxy, 'addRow', list(unname(as.list(data)), rn, resetPaging))
 }
 
 #' @rdname proxy


### PR DESCRIPTION
Closes #959 

This is due to the change in R 3.4.0

<img width="748" alt="image" src="https://user-images.githubusercontent.com/8368933/151661359-49b3e479-0023-4173-96a9-a7ade2a104cc.png">

## Example App

```r
library(shiny)
ui <- fluidPage(
  actionButton("add", "Add Row"),
  DT::DTOutput("tbl")
)
sample_row <- function() {
  row <- sample(letters, 1L)
  a <- sample(0:9, 1L)
  b <- sample(letters, 3) |> paste0(collapse = "")
  list(row, A = a, B = b)
}
df <- rbind(
  "a" = c("A" = 1L, "B" = "abc"),
  "b" = c("A" = 2L, "B" = "bcd")
)

server <- function(input, output, session) {
  output$tbl <- DT::renderDT({
    df
  }, server = FALSE)
  proxy <- DT::dataTableProxy("tbl")
  observeEvent(input$add, {
    DT::addRow(proxy, sample_row())
  })
}
shiny::runApp(mget(c("ui", "server")))
```