### PR TITLE
Fix the bug that DT table can't vertically fill the container

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.20.4
+Version: 0.20.5
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - Fix the bug that `addRow()` doesn't support a list of `data` after R 3.4.0, where `structure(NULL, ...)` was deprecated (thanks, @stla @shrektan #959).
 
+- Fix the bug that DT table can't vertically fill the container, e.g., RStudio IDE or FlexDashboard (thanks, @mbojan @shrektan #951).
+
 # CHANGES IN DT VERSION 0.20
 
 ## MAJOR CHANGES

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1389,6 +1389,12 @@ HTMLWidgets.widget({
     var framingHeight = dtWrapper.innerHeight() - dtScrollBody.innerHeight();
     var scrollBodyHeight = availableHeight - framingHeight;
 
+    // we need to set `max-height` to none as datatables library now sets this
+    // to a fixed height, disabling the ability to resize to fill the window,
+    // as it will be set to a fixed 100px under such circumstances, e.g., RStudio IDE,
+    // or FlexDashboard
+    // see https://github.com/rstudio/DT/issues/951#issuecomment-1026464509
+    dtScrollBody.css('max-height', 'none');
     // set the height
     dtScrollBody.height(scrollBodyHeight + 'px');
   },


### PR DESCRIPTION
Fixes #951 

More info on this issue please see https://github.com/rstudio/DT/issues/951#issuecomment-1026464509

# Code

## RStudio IDE

```r
DT::datatable(iris)
```

## FlexDashboard

``````rmd
---
title: "RMarkdown Document"
output: flexdashboard::flex_dashboard
---

```{r table}
library(DT)
library(flexdashboard)
data.frame(x = 1:100) |> datatable()
```
``````

# Before the Patch

## In RStudio IDE

<img width="601" alt="image" src="https://user-images.githubusercontent.com/8368933/151914008-2a60d852-6efc-4231-ae4c-dab30c07ffd0.png">


## FlexDashboard

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/8368933/151913991-3e888662-5d8c-4dfe-ae01-7e839b1a1e38.png">


# After the Patch

## In RStudio IDE

<img width="586" alt="image" src="https://user-images.githubusercontent.com/8368933/151913159-c514a29b-b2d5-49b0-814f-b0aacbd482c2.png">

## FlexDashboard

<img width="893" alt="image" src="https://user-images.githubusercontent.com/8368933/151913943-5d22e22c-2525-4420-ad46-2da0e7787d43.png">
