### PR TITLE
Be able to specify the styled rows in `formatXXX()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - Add the `zero.print` argument to `formatPercentage()`, `formatCurrency()`, `formatSignif()` and `formatRound()`, which allows to control the format of zero values. It's useful when the data is "sparse" (thanks, @shrektan #953).
 
-- `formatXXX()` functions now gain a new argument `rows` (starting from 1), which can be used to specify the rows that the "style" should be applied to. Note that it only works expected in the client-side processing mode, i.e., `server = FALSE`. `formatStyle()` is the only exception that doesn't have this argument and should use `styleRow()` instead. (thanks, @jrecasens @shrektan #520)
+- `formatXXX()` functions now gain a new argument `rows` (starting from 1), which can be used to specify the rows that the "style" should be applied to. Note that it only works expected in the client-side processing mode, i.e., `server = FALSE`. `formatStyle()` is the only exception that doesn't have this argument and should use `styleRow()` instead (thanks, @jrecasens @shrektan #520).
 
 ## MAJOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Add the `zero.print` argument to `formatPercentage()`, `formatCurrency()`, `formatSignif()` and `formatRound()`, which allows to control the format of zero values. It's useful when the data is "sparse" (thanks, @shrektan #953).
 
+- `formatXXX()` functions now gain a new argument `rows` (starting from 1), which can be used to specify the rows that the "style" should be applied to. Note that it only works expected in the client-side processing mode, i.e., `server = FALSE`. `formatStyle()` is the only exception that doesn't have this argument and should use `styleRow()` instead. (thanks, @jrecasens @shrektan #520)
+
 ## MAJOR CHANGES
 
 - Now users can provide column names of the data to `options$columnDefs$targets`. Previously, it only supports column indexes or "_all" (thanks, @shrektan #948).

--- a/R/format.R
+++ b/R/format.R
@@ -41,10 +41,12 @@ formatColumns = function(table, columns, template, ..., appendTo = c('columnDefs
 #' @param before whether to place the currency symbol before or after the values
 #' @param zero.print a string to specify how zeros should be formatted.
 #'   Useful for when many zero values exist. If \code{NULL}, keeps zero as it is.
-#' @param rows an integer vector to specify the only rows that the style applies to.
+#' @param rows an integer vector (starting from 1) to specify the only rows
+#'   that the style applies to.
 #'   By default, it's \code{NULL}, meaning all rows should be formatted. Note,
 #'   \code{formatStyle()} doesn't support this argument and you should use
-#'   \code{styleRow()} instead.
+#'   \code{styleRow()} instead. In addition, this only works expected in the
+#'   client-side processing mode, i.e., \code{server = FALSE}.
 #' @references See \url{https://rstudio.github.io/DT/functions.html} for detailed
 #'   documentation and examples.
 #' @note The length of arguments other than \code{table} should be 1 or the same as
@@ -341,6 +343,7 @@ jsValuesHandleNull = function(x) {
 #' The function \code{styleValue()} uses the column value as the CSS values.
 #'
 #' The function \code{styleRow()} applies the CSS values based on Row Indexes.
+#' This only works expected in the client-side processing mode, i.e., \code{server = FALSE}.
 #'
 #' @param cuts a vector of cut points (sorted increasingly)
 #' @param values a vector of CSS values

--- a/man/formatCurrency.Rd
+++ b/man/formatCurrency.Rd
@@ -94,10 +94,12 @@ equivalent to \code{c('V1', 'V2')})}
 \item{zero.print}{a string to specify how zeros should be formatted.
 Useful for when many zero values exist. If \code{NULL}, keeps zero as it is.}
 
-\item{rows}{an integer vector to specify the only rows that the style applies to.
+\item{rows}{an integer vector (starting from 1) to specify the only rows
+that the style applies to.
 By default, it's \code{NULL}, meaning all rows should be formatted. Note,
 \code{formatStyle()} doesn't support this argument and you should use
-\code{styleRow()} instead.}
+\code{styleRow()} instead. In addition, this only works expected in the
+client-side processing mode, i.e., \code{server = FALSE}.}
 
 \item{prefix}{string to put in front of the column values}
 

--- a/man/formatCurrency.Rd
+++ b/man/formatCurrency.Rd
@@ -19,10 +19,11 @@ formatCurrency(
   digits = 2,
   dec.mark = getOption("OutDec"),
   before = TRUE,
-  zero.print = NULL
+  zero.print = NULL,
+  rows = NULL
 )
 
-formatString(table, columns, prefix = "", suffix = "")
+formatString(table, columns, prefix = "", suffix = "", rows = NULL)
 
 formatPercentage(
   table,
@@ -31,7 +32,8 @@ formatPercentage(
   interval = 3,
   mark = ",",
   dec.mark = getOption("OutDec"),
-  zero.print = NULL
+  zero.print = NULL,
+  rows = NULL
 )
 
 formatRound(
@@ -41,7 +43,8 @@ formatRound(
   interval = 3,
   mark = ",",
   dec.mark = getOption("OutDec"),
-  zero.print = NULL
+  zero.print = NULL,
+  rows = NULL
 )
 
 formatSignif(
@@ -51,10 +54,11 @@ formatSignif(
   interval = 3,
   mark = ",",
   dec.mark = getOption("OutDec"),
-  zero.print = NULL
+  zero.print = NULL,
+  rows = NULL
 )
 
-formatDate(table, columns, method = "toDateString", params = NULL)
+formatDate(table, columns, method = "toDateString", params = NULL, rows = NULL)
 
 formatStyle(
   table,
@@ -89,6 +93,11 @@ equivalent to \code{c('V1', 'V2')})}
 
 \item{zero.print}{a string to specify how zeros should be formatted.
 Useful for when many zero values exist. If \code{NULL}, keeps zero as it is.}
+
+\item{rows}{an integer vector to specify the only rows that the style applies to.
+By default, it's \code{NULL}, meaning all rows should be formatted. Note,
+\code{formatStyle()} doesn't support this argument and you should use
+\code{styleRow()} instead.}
 
 \item{prefix}{string to put in front of the column values}
 

--- a/man/styleInterval.Rd
+++ b/man/styleInterval.Rd
@@ -74,4 +74,5 @@ column values.
 The function \code{styleValue()} uses the column value as the CSS values.
 
 The function \code{styleRow()} applies the CSS values based on Row Indexes.
+This only works expected in the client-side processing mode, i.e., \code{server = FALSE}.
 }


### PR DESCRIPTION
Closes #520

# Code

```r
library(shiny)
library(DT)

data <- iris
data$DATE <- sample(0:500, replace = TRUE, size = nrow(data)) + as.Date("1990-01-01")
rowsOpt = list("top3and12" = c(1:3, 12), "1/5/12/20" = c(1,5,12,20), "all" = NULL)

ui = fluidPage(
  radioButtons("rows", "rows", names(rowsOpt), inline = TRUE),
  radioButtons("fmtfun", "format function", c(
    "formatCurrency", "formatDate", "formatPercentage", "formatRound", "formatSignif", "formatString"
  ), inline = TRUE),
  selectInput("cols", "columns", seq_len(ncol(data)), selected = c(1,3,6), multiple = TRUE),
  DTOutput("tbl")
)
server = function(input, output, session) {
  output$tbl = renderDT({
    styler = function(data) {
      args = list(
        columns = as.integer(input$cols |> req()), rows = rowsOpt[[input$rows]]
      )
      # formatString's default arg won't change anything...
      if (input$fmtfun == "formatString") {
        args = c(args, list(suffix = "--$$"))
      }
      args = c(list(data), args)
      fun = match.fun(input$fmtfun)
      do.call(fun, args)
    }
    datatable(data) |>
      styler()
  }, server = FALSE)
}
runApp(mget(c("ui", "server")))
```

<img width="973" alt="image" src="https://user-images.githubusercontent.com/8368933/152015378-c17a31ab-4dfa-49a3-bca4-f5a334fb21d8.png">
