### PR TITLE
DT parses ajax request correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - Fix the bug that `addRow()` doesn't support a list of `data` after R 3.4.0, where `structure(NULL, ...)` was deprecated (thanks, @stla @shrektan #959).
 
+- Fix the bug that DT can't send out special strings like "=" to the server side correctly (thanks, @shrektan #965).
+
 # CHANGES IN DT VERSION 0.20
 
 ## MAJOR CHANGES

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 - Fix the bug that `addRow()` doesn't support a list of `data` after R 3.4.0, where `structure(NULL, ...)` was deprecated (thanks, @stla @shrektan #959).
 
-- Fix the bug that DT can't send out special strings like "=" to the server side correctly (thanks, @shrektan #965).
+- Fix the bug that DT failed to parse ajax request correctly, when special strings like "=" exist (thanks, @shrektan #965).
 
 # CHANGES IN DT VERSION 0.20
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -557,7 +557,9 @@ sessionDataURL = function(session, data, id, filter) {
   filterFun = function(data, req) {
     # DataTables requests were sent via POST
     params = rawToChar(req$rook.input$read())
+    # I don't think the browser would send out nonASCII strings, but keep it as it is
     Encoding(params) = 'UTF-8'
+    # shiny::parseQueryString() calls httpuv::decodeURIComponent() internally and will handle encoding correctly
     params = shiny::parseQueryString(params, nested = TRUE)
 
     res = tryCatch(filter(data, params), error = function(e) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -551,13 +551,12 @@ dataTableAjax = function(session, data, rownames, filter = dataTablesFilter, out
 
 sessionDataURL = function(session, data, id, filter) {
 
-  URLdecode = shinyFun('URLdecode')
   toJSON = shinyFun('toJSON')
   httpResponse = shinyFun('httpResponse')
 
   filterFun = function(data, req) {
     # DataTables requests were sent via POST
-    params = URLdecode(rawToChar(req$rook.input$read()))
+    params = rawToChar(req$rook.input$read())
     Encoding(params) = 'UTF-8'
     params = shiny::parseQueryString(params, nested = TRUE)
 


### PR DESCRIPTION
Closes #965

Related to #963

Note, I confirm that `shiny::parseQueryString()` will mark the string result to UTF-8 on Windows.

<img width="821" alt="image" src="https://user-images.githubusercontent.com/8368933/153717166-c2cf9410-fdcf-4075-a3f9-aac9a090b524.png">
