### PR TITLE
Allow integer and character columns in `updateFilters()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Authors@R: c(
     person("Bartek", "Szopka", role = c("ctb", "cph"), comment = "jquery.highlight.js in htmlwidgets/lib"),
     person("Alex", "Pickering", role = c("ctb")),
     person("William", "Holmes", role = c("ctb")),
+    person("Mikko", "Marttila", role = c("ctb")),
     person("RStudio, PBC", role = "cph")
     )
 Maintainer: Yihui Xie <xie@yihui.name>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # CHANGES IN DT VERSION 0.22
 
+- Enhancements to `updateFilters()` (#971):
+  - Added support for data with integer and character columns (@mikmart #972).
+  - Fixed an issue with length 1 options causing filters not to update (@mikmart #973).
+  - Fixed an issue with slider limits sometimes being incorrectly scaled (@mikmart #974).
+  - Updates to factor and logical filters now match the initial render (@mikmart #975).
 
 # CHANGES IN DT VERSION 0.21
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -477,14 +477,16 @@ replaceData = function(proxy, data, ..., resetPaging = TRUE, clearSelection = 'a
 updateFilters = function(proxy, data) {
   # calculate the values to be supplied to the filters based on column type
   new_lims = lapply(data, function(x) {
-    if (inherits(x, c('numeric'))) {
+    if (is.numeric(x)) {
       range(x)
-    } else if (inherits(x, c('factor', 'logical'))) {
-      as.character(unique(x))
     } else if (inherits(x, c('Date'))) {
       as.numeric(as.POSIXct.Date(range(x))) * 100
     } else if (inherits(x, 'POSIXt')) {
       round(as.numeric(range(x)), digits = 2) * 100000
+    } else if (inherits(x, c('factor', 'logical'))) {
+      as.character(unique(x))
+    } else if (is.character(x)) {
+      # Character cols only have search -- no concept of limits. Do nothing.
     } else {
       stop('updateFilters() requires all columns to be one of the following classes: numeric, factor, logical, Date, POSIXt')
     }

--- a/inst/examples/DT-updateFilters/DESCRIPTION
+++ b/inst/examples/DT-updateFilters/DESCRIPTION
@@ -1,0 +1,3 @@
+Title: Updating filters
+DisplayMode: Showcase
+Type: Shiny

--- a/inst/examples/DT-updateFilters/README.md
+++ b/inst/examples/DT-updateFilters/README.md
@@ -1,0 +1,1 @@
+This app demonstrates how to use `updateFilters()` to update the limits on column filters after changes to the data, without re-rendering the entire table.

--- a/inst/examples/DT-updateFilters/app.R
+++ b/inst/examples/DT-updateFilters/app.R
@@ -2,6 +2,7 @@ library(shiny)
 library(DT)
 
 tbl <- data.frame(
+  int = -2:2,
   num1 = replace(seq(-2, 2) * 10, 1, Inf),
   num2 = seq(-2, 2) / 1,
   num3 = seq(-2, 2) / 10,
@@ -9,7 +10,8 @@ tbl <- data.frame(
   dttm = round(Sys.time()) + seq(-2, 2) * 3600,
   fct1 = factor(c("A", rep("B", 4)), levels = c("A", "B", "C")),
   fct2 = factor(c(rep("A", 4), "B"), levels = c("A", "B", "C")),
-  bool = c(NA, TRUE, TRUE, FALSE, FALSE)
+  bool = c(NA, TRUE, TRUE, FALSE, FALSE),
+  chr = c("foo", "bar", "baz", "baz", "baz")
 )
 
 ui <- fluidPage(

--- a/inst/examples/DT-updateFilters/app.R
+++ b/inst/examples/DT-updateFilters/app.R
@@ -1,0 +1,45 @@
+library(shiny)
+library(DT)
+
+tbl <- data.frame(
+  num1 = replace(seq(-2, 2) * 10, 1, Inf),
+  num2 = seq(-2, 2) / 1,
+  num3 = seq(-2, 2) / 10,
+  date = Sys.Date() + seq(-2, 2),
+  dttm = round(Sys.time()) + seq(-2, 2) * 3600,
+  fct1 = factor(c("A", rep("B", 4)), levels = c("A", "B", "C")),
+  fct2 = factor(c(rep("A", 4), "B"), levels = c("A", "B", "C")),
+  bool = c(NA, TRUE, TRUE, FALSE, FALSE)
+)
+
+ui <- fluidPage(
+  sliderInput("rows", "Slice rows", 0, 5, value = c(1, 4), step = 1),
+  DTOutput("table_sliced"),
+  tags$hr(),
+  DTOutput("table_original"),
+)
+
+server <- function(input, output, session) {
+  simple_dt <- function(data, caption) {
+    datatable(data, caption = caption, filter = "top", options = list(dom = "t"))
+  }
+
+  # Render tables only once to begin with
+  output$table_sliced <- renderDT(simple_dt(tbl, caption = "Sliced data"))
+  output$table_original <- renderDT(simple_dt(tbl, caption = "Original data"))
+
+  # Update table_sliced based on input slider row selection
+  tbl_slice <- eventReactive(input$rows, {
+    r1 <- input$rows[1]
+    r2 <- input$rows[2]
+    tbl[seq(r1, r2), ]
+  })
+
+  proxy <- dataTableProxy("table_sliced")
+  observeEvent(tbl_slice(), {
+    replaceData(proxy, tbl_slice())
+    updateFilters(proxy, tbl_slice())
+  })
+}
+
+shinyApp(ui, server)

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1424,8 +1424,11 @@ HTMLWidgets.widget({
           if (i === 0) return;  // first column is row names
           k = i - 1;
         }
-        // Update the filters to reflect the updated data
-        set_filter_lims(td, newLims[k]);
+        // Update the filters to reflect the updated data.
+        // Allow "falsy" (e.g. NULL) to signify a no-op.
+        if (newLims[k]) {
+          set_filter_lims(td, newLims[k]);
+        }
       });
     };
 


### PR DESCRIPTION
Part of #971.

This PR allows integer and character columns to be included in the data whose filters are being updated.

I also added an example app to demonstrate (and test) `updateFilters()`.
