### PR TITLE
Fix updating filters with length 1 limits

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -494,6 +494,9 @@ updateFilters = function(proxy, data) {
   # 10; e.g. 5.7 will be converted to 57
   new_lims = unname(lapply(new_lims, function(x) if (is.numeric(x)) x * 10 else x))
 
+  # ensure limits are always passed as JS arrays, not scalars
+  new_lims = lapply(new_lims, as.list)
+
   # Trigger the JavaScript to update the filters
   invokeRemote(proxy, 'updateFilters', list(new_lims))
 }


### PR DESCRIPTION
Part of #971.

If `updateFilters()` sets tries to set new limits for a select filter that would have length 1, the data in the update message gets unboxed into a scalar. However, the JS code that accesses these values expects the message to always contain only arrays.
