### PR TITLE
Use filter scale when updating limits

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -482,17 +482,16 @@ updateFilters = function(proxy, data) {
     } else if (inherits(x, c('factor', 'logical'))) {
       as.character(unique(x))
     } else if (inherits(x, c('Date'))) {
-      as.numeric(as.POSIXct.Date(range(x))) * 100
+      as.numeric(as.POSIXct.Date(range(x))) * 1000
     } else if (inherits(x, 'POSIXt')) {
-      round(as.numeric(range(x)), digits = 2) * 100000
+      round(as.numeric(range(x)), digits = 2) * 1000
     } else {
       stop('updateFilters() requires all columns to be one of the following classes: numeric, factor, logical, Date, POSIXt')
     }
   })
 
-  # as of DT 0.19, numeric values fed to the sliders need to be multiplied by
-  # 10; e.g. 5.7 will be converted to 57
-  new_lims = unname(lapply(new_lims, function(x) if (is.numeric(x)) x * 10 else x))
+  # make sure JS gets an array, not an object
+  new_lims = unname(new_lims)
 
   # Trigger the JavaScript to update the filters
   invokeRemote(proxy, 'updateFilters', list(new_lims))

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -94,11 +94,15 @@ var set_filter_lims = function(td, new_vals) {
     dropdown.setValue(old_vals);
 
   } else if (['number', 'integer', 'date', 'time'].includes(td.getAttribute('data-type'))) {
+    // Apply internal scaling to new limits
+    var slider = $(td).find('.noUi-target').eq(0);
+    var scale = Math.pow(10, Math.max(0, +slider.data('scale') || 0));
+    new_vals = new_vals.map(function(x) { return x * scale; });
+
     // Note what the new limits will be just for this filter
     var new_lims = new_vals.slice();
-
+    
     // Determine the current values and limits
-    var slider = $(td).find('.noUi-target').eq(0);
     var old_vals = slider.val().map(Number);
     var old_lims = slider.noUiSlider('options').range;
     old_lims = [old_lims.min, old_lims.max];


### PR DESCRIPTION
Part of #971.

Updated numeric limits were only correct for reals with 1 significant digit, dates with 0 significant digits, and datetimes with 3 significant digits. That's because they didn't take into account the `scale` applied to the internal representation of the slider limits.

This PR updates `updateLimits()` to rescale the new limits before applying them, fixing the issue.
