### PR TITLE
Update factors and logicals consistently with initial render

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -479,8 +479,10 @@ updateFilters = function(proxy, data) {
   new_lims = lapply(data, function(x) {
     if (inherits(x, c('numeric'))) {
       range(x)
-    } else if (inherits(x, c('factor', 'logical'))) {
-      as.character(unique(x))
+    } else if (is.logical(x)) {
+      c("true", "false", if (anyNA(x)) "na")
+    } else if (is.factor(x)) {
+      levels(x)
     } else if (inherits(x, c('Date'))) {
       as.numeric(as.POSIXct.Date(range(x))) * 100
     } else if (inherits(x, 'POSIXt')) {


### PR DESCRIPTION
Part of #971.

`updateFilter()` should apply new limits consistently with how they would appear if fully re-rendered (and thus calculated internally with `filterRow()`). Currently booleans always show all options, and `NA` if there are any, while factors let you pick from their levels, regardless of whether or not they are present in the data:

https://github.com/rstudio/DT/blob/815872d67141bb053ed9defd6b72cbaed2aa6668/R/datatables.R#L684-L692

This PR changes the new limits for factors and booleans calculated by `updateFilter()` to match those found by `filterRow()`.
