### PR TITLE
Refactor `filterRow()` and update disabled state in `updateFilters()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
   - Fixed an issue with length 1 options causing filters not to update (@mikmart #973).
   - Fixed an issue with slider limits sometimes being incorrectly scaled (@mikmart #974).
   - Updates to factor and logical filters now match the initial render (@mikmart #975).
+  - Disabled status is now also affected by updates (@mikmart #977).
 
 # CHANGES IN DT VERSION 0.21
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -625,13 +625,25 @@ tableHead = function(names, type = c('head', 'foot'), escape = TRUE, ...) {
   f(tags$tr(lapply(escapeColNames(names, escape), tags$th)), ...)
 }
 
-#' @importFrom htmltools tagList
 filterRow = function(
   data, rownames = TRUE,
   filter = list(position = 'none', clear = TRUE, plain = FALSE, vertical = FALSE, opacity = 1)
 ) {
   if (filter$position == 'none') return()
-  tds = list()
+
+  filters = columnFilters(data)
+  row = columnFilterRow(filters, options = filter)
+
+  # no filter for row names (may change in future)
+  if (rownames) {
+    row$children[[1]][[1]] = tags$td('')
+  }
+
+  row
+}
+
+# calculate properties needed to represent a filter control in JavaScript
+columnFilters = function(data) {
   decimals = function(x) {
     x = abs(na.omit(x))
     if (length(x) == 0) return()
@@ -639,76 +651,115 @@ filterRow = function(
     while (i < 15 && any(round(x, i) != x)) i = i + 1L
     if (i > 0L) i
   }
-  for (j in seq_len(ncol(data))) {
-    if (j == 1 && rownames) {
-      tds[[j]] = tags$td('')  # no filter for row names (may change in future)
-      next
-    }
-    t = NULL
-    d = data[, j]
-    x = if (is.numeric(d) || is.Date(d)) {
-      t = if (is.numeric(d)) {
+
+  lapply(data, function(d) {
+    type = NULL
+    control = 'none'
+    params = list()
+    disabled = FALSE
+
+    if (is.numeric(d) || is.Date(d)) {
+      control = 'slider'
+      type = if (is.numeric(d)) {
         if (is.integer(d)) 'integer' else 'number'
       } else 'time'
-      if (t == 'time') {
+      
+      # convert date/times to JavaScript format
+      if (type == 'time') {
         # JavaScript does have the Date type like R (YYYY-mm-dd without time)
         if (inherits(d, 'Date')) {
-          d = as.POSIXct(d); t = 'date'
+          d = as.POSIXct(d); type = 'date'
         }
         d = as.numeric(d) * 1000  # use milliseconds for JavaScript
       }
+
+      # find range
       suppressWarnings({
         d1 = min(d, na.rm = TRUE)
         d2 = max(d, na.rm = TRUE)
       })
+
+      # find scale to avoid fp issues
       dec = decimals(d)
       if (!is.null(dec)) {
         d1 = floor(d1 * 10^dec) / 10^dec
         d2 = ceiling(d2 * 10^dec) / 10^dec
       }
-      is_vert <- filter$vertical
 
-      if (is.finite(d1) && is.finite(d2) && d2 > d1) tags$div(
-        style = paste0('display: none;position: absolute;width: 200px;opacity: ', filter$opacity),
-        tags$div(`data-min` = d1, `data-max` = d2, `data-scale` = dec),
-        if (is_vert) tagList(tags$span(style = 'position: absolute; bottom: 0px; left: 15px;'),
-                             tags$span(style = 'display: none;', HTML('&nbsp;')),
-                             tags$span(style = 'position: absolute; top: 2px; left: 15px;')
-                             )
-        else tagList(tags$span(style = 'float: left;'),
-                     tags$span(style = 'float: right;'))
-      ) else {
-        t = 'disabled'
-        NULL
+      disabled = !(is.finite(d1) && is.finite(d2) && d2 > d1)
+      if (disabled) {
+        # still need some finite numbers for noUiSlider to not crash
+        d1 = 0
+        d2 = 1
       }
+
+      params = list(min = d1, max = d2, scale = dec)
     } else if (is.factor(d) || is.logical(d)) {
-      if (length(unique(d)) <= 1) {
-        t = 'disabled'
-      } else if (is.logical(d)) {
-        t = 'logical'
-        d = c('true', 'false', if (any(is.na(d))) 'na')
+      control = 'select'
+      disabled = (length(unique(d)) <= 1)
+
+      if (is.logical(d)) {
+        type = 'logical'
+        d = c('true', 'false', if (anyNA(d)) 'na')
       } else {
-        t = 'factor'
+        type = 'factor'
         d = levels(d)
       }
-      if (t != 'disabled') tags$div(
+
+      opts = native_encode(jsonlite::toJSON(as.character(d)))
+      params = list(options = opts)
+    } else if (is.character(d)) {
+      type = 'character'
+      disabled = (length(unique(d)) <= 1)
+    }
+
+    list(control = control, type = type, params = params, disabled = disabled)
+  })
+}
+
+#' @importFrom htmltools tagList
+columnFilterRow = function(filters, options = list()) {
+  defaults = list(clear = TRUE, plain = FALSE, vertical = FALSE, opacity = 1)
+  options = modifyList(defaults, options)
+
+  tds = lapply(filters, function(f) {
+    p = f$params
+    
+    # create HTML for the control element
+    ctrl = if (f$control == 'slider') {
+      tags$div(
+        style = paste0('display: none;position: absolute;width: 200px;opacity: ', options$opacity),
+        tags$div(`data-min` = p$min, `data-max` = p$max, `data-scale` = p$scale),
+        if (options$vertical) tagList(
+          tags$span(style = 'position: absolute; bottom: 0px; left: 15px;'),
+          tags$span(style = 'display: none;', HTML('&nbsp;')),
+          tags$span(style = 'position: absolute; top: 2px; left: 15px;')
+        )
+        else tagList(
+          tags$span(style = 'float: left;'),
+          tags$span(style = 'float: right;')
+        )
+      )
+    } else if (f$control == 'select') {
+      tags$div(
         tags$select(
-          multiple = 'multiple', style = 'width: 100%;',
-          `data-options` = native_encode(jsonlite::toJSON(as.character(d)))
+          multiple = 'multiple',
+          style = 'width: 100%;',
+          `data-options` = p$options
         ),
         style = 'width: 100%; display: none;'
       )
-    } else if (is.character(d)) {
-      t = if (length(unique(d)) <= 1) 'disabled' else 'character'
-      NULL
     }
-    clear = filter$clear
-    input = if (filter$plain) {
+
+    # create HTML for the search box input
+    clear = options$clear
+    input = if (options$plain) {
       tags$div(
         style = 'margin-bottom: auto;',
         tags$input(
           type = if (clear) 'search' else 'text', placeholder = 'All',
-          style = 'width: 100%;'
+          style = 'width: 100%;',
+          disabled = if (f$disabled) ""
         )
       )
     } else {
@@ -717,16 +768,18 @@ filterRow = function(
         style = 'margin-bottom: auto;',
         tags$input(
           type = 'search', placeholder = 'All', class = 'form-control',
-          style = 'width: 100%;'
+          style = 'width: 100%;',
+          disabled = if (f$disabled) ""
         ),
         if (clear) tags$span(
           class = 'glyphicon glyphicon-remove-circle form-control-feedback'
         )
       )
     }
-    x = tagList(input, x)
-    tds[[j]] = tags$td(x, `data-type` = t, style = 'vertical-align: top;')
-  }
+    
+    tags$td(tagList(input, ctrl), `data-type` = f$type, style = 'vertical-align: top;')
+  })
+
   tags$tr(tds)
 }
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -734,8 +734,7 @@ columnFilterRow = function(filters, options = list()) {
           tags$span(style = 'position: absolute; bottom: 0px; left: 15px;'),
           tags$span(style = 'display: none;', HTML('&nbsp;')),
           tags$span(style = 'position: absolute; top: 2px; left: 15px;')
-        )
-        else tagList(
+        ) else tagList(
           tags$span(style = 'float: left;'),
           tags$span(style = 'float: right;')
         )

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -475,33 +475,9 @@ replaceData = function(proxy, data, ..., resetPaging = TRUE, clearSelection = 'a
 #' @rdname replaceData
 #' @export
 updateFilters = function(proxy, data) {
-  # calculate the values to be supplied to the filters based on column type
-  new_lims = lapply(data, function(x) {
-    if (is.numeric(x)) {
-      range(x)
-    } else if (inherits(x, c('Date'))) {
-      as.numeric(as.POSIXct.Date(range(x))) * 1000
-    } else if (inherits(x, 'POSIXt')) {
-      round(as.numeric(range(x)), digits = 2) * 1000
-    } else if (is.logical(x)) {
-      c("true", "false", if (anyNA(x)) "na")
-    } else if (is.factor(x)) {
-      levels(x)
-    } else if (is.character(x)) {
-      # Character cols only have search -- no concept of limits. Do nothing.
-    } else {
-      stop('updateFilters() requires all columns to be one of the following classes: numeric, factor, logical, Date, POSIXt')
-    }
-  })
-
   # make sure JS gets an array, not an object
-  new_lims = unname(new_lims)
-
-  # ensure limits are always passed as JS arrays, not scalars
-  new_lims = lapply(new_lims, as.list)
-
-  # Trigger the JavaScript to update the filters
-  invokeRemote(proxy, 'updateFilters', list(new_lims))
+  filters = unname(columnFilters(data))
+  invokeRemote(proxy, 'updateFilters', list(filters))
 }
 
 invokeRemote = function(proxy, method, args = list()) {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -433,7 +433,9 @@ HTMLWidgets.widget({
 
         var $td = $(td), type = $td.data('type'), filter;
         var $input = $td.children('div').first().children('input');
-        $input.prop('disabled', !table.settings()[0].aoColumns[i].bSearchable || type === 'disabled');
+        var disabled = $input.prop('disabled');
+        var searchable = table.settings()[0].aoColumns[i].bSearchable;
+        $input.prop('disabled', !searchable || disabled);
         $input.on('input blur', function() {
           $input.next('span').toggle(Boolean($input.val()));
         });

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -73,6 +73,11 @@ window.DTWidget = DTWidget;
 
 // A helper function to update the properties of existing filters
 var setFilterProps = function(td, props) {
+  // Update enabled/disabled state
+  var $input = $(td).find("input").first();
+  var searchable = $input.data('searchable', searchable);
+  $input.prop('disabled', !searchable || props.disabled);
+
   // Based on the filter type, set its new values
   var type = td.getAttribute('data-type');
   if (['factor', 'logical'].includes(type)) {
@@ -439,6 +444,7 @@ HTMLWidgets.widget({
         var disabled = $input.prop('disabled');
         var searchable = table.settings()[0].aoColumns[i].bSearchable;
         $input.prop('disabled', !searchable || disabled);
+        $input.data('searchable', searchable); // for updating later
         $input.on('input blur', function() {
           $input.next('span').toggle(Boolean($input.val()));
         });

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -71,12 +71,15 @@ DTWidget.formatDate = function(data, method, params) {
 
 window.DTWidget = DTWidget;
 
-// A helper function to update the lims of the existing filters
-var set_filter_lims = function(td, new_vals) {
+// A helper function to update the properties of existing filters
+var setFilterProps = function(td, props) {
   // Based on the filter type, set its new values
-  if (['factor', 'logical'].includes(td.getAttribute('data-type'))) {
+  var type = td.getAttribute('data-type');
+  if (['factor', 'logical'].includes(type)) {
     // Reformat the new dropdown options for use with selectize
-    new_vals = new_vals.map(function(item) {return {text: item, value: item}});
+    var new_vals = props.params.options.map(function(item) {
+      return { text: item, value: item };
+    });
 
     // Find the selectize object
     var dropdown = $(td).find('.selectized').eq(0)[0].selectize;
@@ -93,11 +96,11 @@ var set_filter_lims = function(td, new_vals) {
     // Preserve the existing values
     dropdown.setValue(old_vals);
 
-  } else if (['number', 'integer', 'date', 'time'].includes(td.getAttribute('data-type'))) {
-    // Apply internal scaling to new limits
+  } else if (['number', 'integer', 'date', 'time'].includes(type)) {
+    // Apply internal scaling to new limits. Updating scale not yet implemented.
     var slider = $(td).find('.noUi-target').eq(0);
     var scale = Math.pow(10, Math.max(0, +slider.data('scale') || 0));
-    new_vals = new_vals.map(function(x) { return x * scale; });
+    var new_vals = [props.params.min, props.params.max].map(function(x) { return x * scale; });
 
     // Note what the new limits will be just for this filter
     var new_lims = new_vals.slice();
@@ -1422,18 +1425,18 @@ HTMLWidgets.widget({
     }
 
     // update table filters (set new limits of sliders)
-    methods.updateFilters = function(newLims) {
+    methods.updateFilters = function(newProps) {
       // loop through each filter in the filter row
       filterRow.each(function(i, td) {
         var k = i;
-        if (filterRow.length > newLims.length) {
+        if (filterRow.length > newProps.length) {
           if (i === 0) return;  // first column is row names
           k = i - 1;
         }
         // Update the filters to reflect the updated data.
         // Allow "falsy" (e.g. NULL) to signify a no-op.
-        if (newLims[k]) {
-          set_filter_lims(td, newLims[k]);
+        if (newProps[k]) {
+          setFilterProps(td, newProps[k]);
         }
       });
     };


### PR DESCRIPTION
Part of #971.

This PR factors out the filter property calculations (like limits and disabled status) from `filterRow()`  into a new `columnFilters()` method. That common method is then used for both the initial render, and subsequent updates with `updateFilters()`, ensuring consistency.

As it flowed naturally into the above changes, I also updated the JS side for `updateFilters()` to also manage the enabled/disabled state of the controls.

There's a bit more going on in this PR, but I tried to group my commits sensibly. Hopefully that helps with review.