### PR TITLE
Fix `updateFilters()` with un-searchable columns

### DIFF
--- a/inst/examples/DT-updateFilters/app.R
+++ b/inst/examples/DT-updateFilters/app.R
@@ -2,10 +2,10 @@ library(shiny)
 library(DT)
 
 tbl <- data.frame(
-  int = -2:2,
+  int = seq(-2, 2),
   num1 = seq(-2, 2) / 10,
   num2 = replace(seq(-2, 2) * 10, 1, -Inf),
-  date = Sys.Date() + seq(-2, 2),
+  date = replace(Sys.Date() + seq(-2, 2), 1, NA),
   dttm = round(Sys.time()) + seq(-2, 2) * 3600,
   fct1 = factor(c("A", rep("B", 3), "C")),
   fct2 = factor(c(rep("A", 4), "B"), levels = c("A", "B", "C")),

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -74,7 +74,7 @@ window.DTWidget = DTWidget;
 // A helper function to update the properties of existing filters
 var setFilterProps = function(td, props) {
   // Update enabled/disabled state
-  var $input = $(td).find("input").first();
+  var $input = $(td).find('input').first();
   var searchable = $input.data('searchable');
   $input.prop('disabled', !searchable || props.disabled);
 
@@ -105,11 +105,11 @@ var setFilterProps = function(td, props) {
     // Apply internal scaling to new limits. Updating scale not yet implemented.
     var slider = $(td).find('.noUi-target').eq(0);
     var scale = Math.pow(10, Math.max(0, +slider.data('scale') || 0));
-    var new_vals = [props.params.min, props.params.max].map(function(x) { return x * scale; });
+    var new_vals = [props.params.min * scale, props.params.max * scale];
 
     // Note what the new limits will be just for this filter
     var new_lims = new_vals.slice();
-    
+
     // Determine the current values and limits
     var old_vals = slider.val().map(Number);
     var old_lims = slider.noUiSlider('options').range;

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -75,7 +75,7 @@ window.DTWidget = DTWidget;
 var setFilterProps = function(td, props) {
   // Update enabled/disabled state
   var $input = $(td).find("input").first();
-  var searchable = $input.data('searchable', searchable);
+  var searchable = $input.data('searchable');
   $input.prop('disabled', !searchable || props.disabled);
 
   // Based on the filter type, set its new values


### PR DESCRIPTION
Closes #971.

- Fixed an issue where updating filters was writing to instead of reading the `searchable` status of the filter when determining whether or not they should be disabled. This was introduced in #977 so hasn't made it into "newsworthy" status yet.
- Added an example of missing values in sliders to the demo app.
- Some minor stylistic changes to better fit the code-base style.