### PR TITLE
Remove encode_plus(), a regression of #966

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.21.1
+Version: 0.21.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
   - Updates to factor and logical filters now match the initial render (@mikmart #975).
   - Disabled status is now also affected by updates (@mikmart #977).
 
+## BUG FIXES
+
+- Fix a bug that the column filter didn't work for strings like "+" (@stephan-hutter @shrektan #980).
+
 # CHANGES IN DT VERSION 0.21
 
 ## NEW FEATURES

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -418,13 +418,6 @@ HTMLWidgets.widget({
       return $.inArray(val, $.makeArray(array)) > -1;
     };
 
-    // encode + to %2B when searching in the table on server side, because
-    // shiny::parseQueryString() treats + as spaces, and DataTables does not
-    // encode + to %2B (or % to %25) when sending the request
-    var encode_plus = function(x) {
-      return server ? x.replace(/%/g, '%25').replace(/\+/g, '%2B') : x;
-    };
-
     // search the i-th column
     var searchColumn = function(i, value) {
       var regex = false, ci = true;
@@ -432,7 +425,7 @@ HTMLWidgets.widget({
         regex = options.search.regex,
         ci = options.search.caseInsensitive !== false;
       }
-      return table.column(i).search(encode_plus(value), regex, !regex, ci);
+      return table.column(i).search(value, regex, !regex, ci);
     };
 
     if (data.filter !== 'none') {
@@ -509,7 +502,7 @@ HTMLWidgets.widget({
               if (value.length) $input.trigger('input');
               $input.attr('title', $input.val());
               if (server) {
-                table.column(i).search(value.length ? encode_plus(JSON.stringify(value)) : '').draw();
+                table.column(i).search(value.length ? JSON.stringify(value) : '').draw();
                 return;
               }
               // turn off filter if nothing selected


### PR DESCRIPTION
Closes #980 

Now filtering `+` or `%` works.

```r
library(shiny)
library(DT)

shinyApp(
  ui = fluidPage(DTOutput('tbl')),
  server = function(input, output) {
    test_tbl <- data.frame(call = as.factor(c("0","-","+","+","0","%")), num = c(1,2,3,4,5,6))
    output$tbl = renderDT(DT::datatable(test_tbl, filter = "top"))
  }
)
```