### PR TITLE
Server-side search optimizations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   - Updates to factor and logical filters now match the initial render (@mikmart #975).
   - Disabled status is now also affected by updates (@mikmart #977).
 
+- New functions `doColumnSearch()` and `doGlobalSearch()` let you do server-side searching with filter search strings. These are particularly useful in conjunction with `updateFilters()` for implementing dynamic limits for filter controls based on currently filtered data (@mikmart #982).
+
 - Server-side searching is now faster when multiple filters are active (@mikmart).
 
 ## BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   - Updates to factor and logical filters now match the initial render (@mikmart #975).
   - Disabled status is now also affected by updates (@mikmart #977).
 
+- Server-side searching is now faster when multiple filters are active (@mikmart).
+
 ## BUG FIXES
 
 - Fix a bug that the column filter didn't work for strings like "+" (@stephan-hutter @shrektan #980).

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -619,16 +619,17 @@ dataTablesFilter = function(data, params) {
     # if the j-th column is not searchable or the search string is "", skip it
     if (col[['searchable']] != 'true') next
     if ((k <- col[['search']][['value']]) == '') next
-    j = as.integer(j)
-    dj = data[, j + 1]
     column_opts = list(
       regex = col[['search']][['regex']] != 'false',
       caseInsensitive = global_opts$caseInsensitive
     )
+    j = as.integer(j)
+    dj = data[i, j + 1]
     ij = doColumnSearch(dj, k, options = column_opts)
-    i = intersect(ij, i)
+    i = intersect(i[ij], i)
     if (length(i) == 0) break
   }
+
   if (length(i) != n) data = data[i, , drop = FALSE]
   iAll = i  # row indices of filtered data
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -626,16 +626,14 @@ dataTablesFilter = function(data, params) {
     )
     j = as.integer(j)
     dj = data[i, j + 1]
-    ij = doColumnSearch(dj, k, options = column_opts)
-    i = intersect(i[ij], i)
+    i = i[doColumnSearch(dj, k, options = column_opts)]
     if (length(i) == 0) break
   }
 
   # global searching
   if (length(i) && any((k <- q$search[['value']]) != '')) {
     dg = data[i, searchable, drop = FALSE]
-    ig = doGlobalSearch(dg, k, options = global_opts)
-    i = intersect(i[ig], i)
+    i = i[doGlobalSearch(dg, k, options = global_opts)]
   }
 
   if (length(i) != n) data = data[i, , drop = FALSE]

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -603,7 +603,7 @@ dataTablesFilter = function(data, params) {
     if (q$columns[[j]][['searchable']] == 'true') searchable[j] = TRUE
   }
 
-  # global searching
+  # global searching options (column search shares caseInsensitive)
   # for some reason, q$search might be NULL, leading to error `if (logical(0))`
   global_opts = list(
     smart = !identical(q$search[['smart']], 'false'),
@@ -611,7 +611,8 @@ dataTablesFilter = function(data, params) {
     caseInsensitive = q$search[['caseInsensitive']] == 'true'
   )
 
-  i = doGlobalSearch(data[searchable], q$search[['value']], options = global_opts)
+  # start searching with all rows
+  i = seq_len(n)
 
   # search by columns
   if (length(i)) for (j in names(q$columns)) {
@@ -628,6 +629,13 @@ dataTablesFilter = function(data, params) {
     ij = doColumnSearch(dj, k, options = column_opts)
     i = intersect(i[ij], i)
     if (length(i) == 0) break
+  }
+
+  # global searching
+  if (length(i) && any((k <- q$search[['value']]) != '')) {
+    dg = data[i, searchable, drop = FALSE]
+    ig = doGlobalSearch(dg, k, options = global_opts)
+    i = intersect(i[ig], i)
   }
 
   if (length(i) != n) data = data[i, , drop = FALSE]

--- a/tests/testit/test-search.R
+++ b/tests/testit/test-search.R
@@ -1,5 +1,9 @@
 library(testit)
 
+# Factors and strings are searched differently.
+# Older versions of R don't have this set.
+op <- options(stringsAsFactors = FALSE)
+
 assert('searching integer values works', {
   x = seq(-2, 2)
   (setequal(doColumnSearch(x, '0 ... 2'), 3:5))
@@ -159,3 +163,6 @@ assert('server-side search handler ignores NULL search', {
   out = dataTablesFilter(tbl, query)
   (setequal(out$DT_rows_all, 1:3))
 })
+
+# Restore stringsAsFactors
+options(op)

--- a/tests/testit/test-search.R
+++ b/tests/testit/test-search.R
@@ -2,7 +2,7 @@ library(testit)
 
 # Factors and strings are searched differently.
 # Older versions of R don't have this set.
-op <- options(stringsAsFactors = FALSE)
+op = options(stringsAsFactors = FALSE)
 
 assert('searching integer values works', {
   x = seq(-2, 2)

--- a/tests/testit/test-search.R
+++ b/tests/testit/test-search.R
@@ -148,3 +148,14 @@ assert('server-side search handler skips unsearchable columns', {
   out = dataTablesFilter(tbl, query)
   (setequal(out$DT_rows_all, 1L))
 })
+
+assert('server-side search handler ignores NULL search', {
+  tbl = data.frame(
+    foo = c('foo', 'bar', 'baz'),
+    bar = c('bar', 'baz', 'foo')
+  )
+
+  query = clientQuery(tbl, NULL)
+  out = dataTablesFilter(tbl, query)
+  (setequal(out$DT_rows_all, 1:3))
+})


### PR DESCRIPTION
While working on #982 I thought of two optimizations to speed up server-side searching. This PR:

1. Doesn't bother searching rows that have already been ruled out by earlier searches.
2. Does the (much more expensive) global search after the (quicker) column searches have already been applied.

I also added some infrastructure to help test the server-side search handler `dataTablesFilter()`.

Benchmarking, I saw a ~20x speed improvement for a 340k x 6 dataset with a global search and two fairly specific column filters:

``` r
library(nycflights13)

# Keep the client query a reasonable size with a subset of columns
flights0 <- flights[c("year", "month", "day", "carrier", "flight", "tailnum")]
flights0 <- as.data.frame(flights0)

# Client-side query with global search and two column filters
query = list(
  draw = "0", start = "0", length = "10", escape = "true",
  search = list(
    value = "N6", regex = "false", caseInsensitive = "true",
    smart = "true"
  ), columns = list(
    `0` = list(
      searchable = "true",
      search = list(value = "", regex = "false")
    ), `1` = list(
      searchable = "true", search = list(
        value = "1 ... 1",
        regex = "false"
      )
    ), `2` = list(
      searchable = "true",
      search = list(value = "", regex = "false")
    ), `3` = list(
      searchable = "true", search = list(value = "UA", regex = "false")
    ),
    `4` = list(searchable = "true", search = list(
      value = "",
      regex = "false"
    )), `5` = list(
      searchable = "true",
      search = list(value = "", regex = "false")
    )
  )
)

# Before this branch
system.time(res0 <- DT:::dataTablesFilter(flights0, query))
#>    user  system elapsed 
#>    0.5     0.0     0.5 

# With this branch
devtools::load_all()
system.time(res1 <- dataTablesFilter(flights0, query))
#>    user  system elapsed 
#>    0.00    0.00    0.02 

identical(res0, res1)
#> [1] TRUE
```
