### PR TITLE
Fix `doGlobalSearch()` with tibbles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Suggests:
     shiny (>= 1.6),
     bslib,
     future,
-    testit
+    testit,
+    tibble
 VignetteBuilder: knitr
 RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - When a `datatable()` is created outside a Shiny app, the `selection` argument won't work (thanks, @bartekch, #1043).
 
+- `doGloblSearch()` now works correctly when the input data frame is a tibble (@mikmart, #1044).
+
 # CHANGES IN DT VERSION 0.26
 
 - Upgraded DataTables to v1.12.1.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -779,7 +779,7 @@ doGlobalSearch = function(data, search_string, options = list()) {
     for (j in seq_len(ncol(data))) {
       for (k in seq_len(nv)) {
         i0 = grep2(
-          v[k], as.character(data[, j]),
+          v[k], as.character(data[, j, drop = TRUE]),
           fixed = !(options$regex %||% FALSE),
           ignore.case = options$caseInsensitive %||% TRUE
         )

--- a/tests/testit/test-search.R
+++ b/tests/testit/test-search.R
@@ -70,6 +70,16 @@ assert('empty search returns everything', {
   (setequal(doColumnSearch(tbl$foo, NULL), 1:2))
 })
 
+assert('global search works for tibbles', {
+  if (requireNamespace("tibble", quietly = TRUE)) {
+    tbl = tibble::tibble(
+      foo = c('foo', 'bar', 'baz'),
+      bar = c('bar', 'baz', 'foo')
+    )
+    (setequal(doGlobalSearch(tbl, 'ba'), 1:3))
+  }
+})
+
 
 # We know from tests above that individual search components work.
 # Here we make sure they are combined correctly for client queries.


### PR DESCRIPTION
Fixes #1044.

I added tibble as a Suggested package in order to add a regression test. Would there be a better way to keep a regression test, and avoid adding the dependency?