### PR TITLE
Allows custom column filter placeholder

### DIFF
--- a/R/datatables.R
+++ b/R/datatables.R
@@ -107,6 +107,9 @@
 #'   columns and the text areas for some other columns by setting
 #'   \code{editable} to a list of the form \code{list(target = TARGET, numeric
 #'   = INDICES1, area = INDICES2)}.
+#' @param columnFilterPlaceholder a length-one character vector to specify the
+#'   placeholder text for the column filter input boxes. Defaults to
+#'   \code{"All"}.
 #' @details \code{selection}:
 #'   \enumerate{
 #'     \item The argument could be a scalar string, which means the selection
@@ -176,7 +179,7 @@ datatable = function(
   fillContainer = getOption('DT.fillContainer', NULL),
   autoHideNavigation = getOption('DT.autoHideNavigation', NULL),
   selection = c('multiple', 'single', 'none'), extensions = list(), plugins = NULL,
-  editable = FALSE
+  editable = FALSE, columnFilterPlaceholder = 'All'
 ) {
 
   # yes, we all hate it
@@ -281,7 +284,7 @@ datatable = function(
   if (is.character(filter)) filter = list(position = match.arg(filter))
   filter = modifyList(list(position = 'none', clear = TRUE, plain = FALSE, vertical = FALSE, opacity = 1), filter)
   # HTML code for column filters
-  filterHTML = as.character(filterRow(data, !is.null(rn) && colnames[1] == ' ', filter))
+  filterHTML = as.character(filterRow(data, !is.null(rn) && colnames[1] == ' ', filter, placeholder = columnFilterPlaceholder))
   # use the first row in the header as the sorting cells when I put the filters
   # in the second row
   if (filter$position == 'top') options$orderCellsTop = TRUE
@@ -630,12 +633,13 @@ tableHead = function(names, type = c('head', 'foot'), escape = TRUE, ...) {
 
 filterRow = function(
   data, rownames = TRUE,
-  filter = list(position = 'none', clear = TRUE, plain = FALSE, vertical = FALSE, opacity = 1)
+  filter = list(position = 'none', clear = TRUE, plain = FALSE, vertical = FALSE, opacity = 1),
+  placeholder = 'All'
 ) {
   if (filter$position == 'none') return()
 
   filters = columnFilters(data)
-  row = columnFilterRow(filters, options = filter)
+  row = columnFilterRow(filters, options = filter, placeholder = placeholder)
 
   # no filter for row names (may change in future)
   if (rownames) {
@@ -721,7 +725,7 @@ columnFilters = function(data) {
 }
 
 #' @importFrom htmltools tagList
-columnFilterRow = function(filters, options = list()) {
+columnFilterRow = function(filters, options = list(), placeholder = 'All') {
   defaults = list(clear = TRUE, plain = FALSE, vertical = FALSE, opacity = 1)
   options = modifyList(defaults, options)
 
@@ -759,7 +763,7 @@ columnFilterRow = function(filters, options = list()) {
       tags$div(
         style = 'margin-bottom: auto;',
         tags$input(
-          type = if (clear) 'search' else 'text', placeholder = 'All',
+          type = if (clear) 'search' else 'text', placeholder = placeholder,
           style = 'width: 100%;',
           disabled = if (f$disabled) ""
         )
@@ -769,7 +773,7 @@ columnFilterRow = function(filters, options = list()) {
         class = if (clear) 'form-group has-feedback' else 'form-group',
         style = 'margin-bottom: auto;',
         tags$input(
-          type = 'search', placeholder = 'All', class = 'form-control',
+          type = 'search', placeholder = placeholder, class = 'form-control',
           style = 'width: 100%;',
           disabled = if (f$disabled) ""
         ),

--- a/man/coerceValue.Rd
+++ b/man/coerceValue.Rd
@@ -27,11 +27,11 @@ This function only works with integer, double, date, time (\code{POSIXlt} or
 }
 \examples{
 library(DT)
-coerceValue("100", 1L)
-coerceValue("1.23", 3.1416)
-coerceValue("2018-02-14", Sys.Date())
-coerceValue("2018-02-14T22:18:52Z", Sys.time())
-coerceValue("setosa", iris$Species)
-coerceValue("setosa2", iris$Species)  # NA
-coerceValue("FALSE", TRUE)  # not supported
+coerceValue('100', 1L)
+coerceValue('1.23', 3.1416)
+coerceValue('2018-02-14', Sys.Date())
+coerceValue('2018-02-14T22:18:52Z', Sys.time())
+coerceValue('setosa', iris$Species)
+coerceValue('setosa2', iris$Species)  # NA
+coerceValue('FALSE', TRUE)  # not supported
 }

--- a/man/dataTableAjax.Rd
+++ b/man/dataTableAjax.Rd
@@ -57,6 +57,7 @@ table option \code{ajax} automatically. If you are familiar with
 function, you may call this function to get an Ajax URL.
 }
 \examples{
+# !formatR
 DTApp = function(data, ..., options = list()) {
   library(shiny)
   library(DT)

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -81,6 +81,7 @@ container for table, and the latter is used in the server logic to render the
 table.
 }
 \examples{
+# !formatR
 if (interactive()) {
   library(shiny)
   library(DT)

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -24,7 +24,8 @@ datatable(
   selection = c("multiple", "single", "none"),
   extensions = list(),
   plugins = NULL,
-  editable = FALSE
+  editable = FALSE,
+  columnFilterPlaceholder = "All"
 )
 }
 \arguments{
@@ -151,6 +152,10 @@ all columns. Of course, you can request the numeric editing for some
 columns and the text areas for some other columns by setting
 \code{editable} to a list of the form \code{list(target = TARGET, numeric
 = INDICES1, area = INDICES2)}.}
+
+\item{columnFilterPlaceholder}{a length-one character vector to specify the
+placeholder text for the column filter input boxes. Defaults to
+\code{"All"}.}
 }
 \description{
 This function creates an HTML widget to display rectangular data (a matrix or
@@ -218,6 +223,7 @@ You are recommended to escape the table content for security reasons
   web applications.
 }
 \examples{
+# !formatR
 library(DT)
 
 # see the package vignette for examples and the link to website

--- a/man/doColumnSearch.Rd
+++ b/man/doColumnSearch.Rd
@@ -37,11 +37,11 @@ internally by the default \code{filter} function passed to
 that server-side processing returns.
 }
 \examples{
-doGlobalSearch(iris, "versi")
+doGlobalSearch(iris, 'versi')
 doGlobalSearch(iris, "v.r.i", options = list(regex = TRUE))
 
-doColumnSearch(iris$Species, "[\"versicolor\"]")
-doColumnSearch(iris$Sepal.Length, "4 ... 5")
+doColumnSearch(iris$Species, '["versicolor"]')
+doColumnSearch(iris$Sepal.Length, '4 ... 5')
 }
 \seealso{
 The column filters section online for search string formats:

--- a/man/formatCurrency.Rd
+++ b/man/formatCurrency.Rd
@@ -152,6 +152,7 @@ The length of arguments other than \code{table} should be 1 or the same as
   the length of \code{columns}.
 }
 \examples{
+# !formatR
 library(DT)
 m = cbind(matrix(rnorm(120, 1e5, 1e6), 40), runif(40), rnorm(40, 100))
 colnames(m) = head(LETTERS, ncol(m))


### PR DESCRIPTION
This PR allows users to set a custom placeholder for column filters. Currently, it is hard coded to `'All'` which makes it almost impossible to setup easily in other languages. (At our company we use Spanish).

This would be really helpful.