### PR TITLE
Support Bootstrap 5 with `datatable(style = "auto")`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.28.1
+Version: 0.28.2
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN DT VERSION 0.29
 
+- Support Bootstrap 5 with `datatable(style = "auto")` (thanks, @gadenbuie, #1074).
 
 # CHANGES IN DT VERSION 0.28
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -889,7 +889,16 @@ normalizeStyle = function(style) {
   if (is.null(theme)) {
     return('default')
   }
-  style = if ('3' %in% bslib::theme_version(theme)) 'bootstrap' else 'bootstrap4'
+
+  bs_v = as.numeric(bslib::theme_version(theme)[1])
+  # TODO: If DT adds support for BS > 5, update this logic
+  style = if (bs_v > 4)
+      "bootstrap5"
+    else if (bs_v > 3)
+      "bootstrap4"
+    else
+      "bootstrap"
+
   # Have style remember if bslib should be a dependency
   structure(style, bslib = TRUE)
 }

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -892,12 +892,8 @@ normalizeStyle = function(style) {
 
   bs_v = as.numeric(bslib::theme_version(theme)[1])
   # TODO: If DT adds support for BS > 5, update this logic
-  style = if (bs_v > 4)
-      "bootstrap5"
-    else if (bs_v > 3)
-      "bootstrap4"
-    else
-      "bootstrap"
+  if (bs_v > 5) bs_v = 5
+  style = paste0("bootstrap", if (bs_v > 3) bs_v)
 
   # Have style remember if bslib should be a dependency
   structure(style, bslib = TRUE)


### PR DESCRIPTION
Currently, when using a Bootstrap 5 theme from bslib and `style="auto"`, `datatable()` will use `"bootstrap4"` for the style. This results in a somewhat incorrectly styled datatable.

This PR improves the logic to use latest DT-supported Bootstrap styles corresponding to the current bslib theme. In this formulation, future Bootstrap updates would require updating this logic (so I left a todo comment), but if there's an easy way to list the bootstrap versions suppported by DT I could update the PR so that this part doesn't need to be updated when future BS versions are added.