### PR TITLE
Add support for list of classes in `DT2BSClass`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 - Fixed a bug that when using `updateSearch()`, the clear button inside the input box doesn't show up, and the table doesn't update when the input is cleared (thanks, @DavidBlairs, #1082).
 
+- Added support for list of booleans as input to the `class` argument at `DT::datatable()` when `style='bootstrap'`. In other words, you can now select the Bootstrap classes you want to use at `DT::datatable()` by using a list of booleans that select the classes you want to use. In the example below, we are producing a new HTML table that uses the `stripe` and `hover` Bootstrap classes:
+
+```r
+DT::datatable(mtcars, class=list(stripe=T, compact=F, hover=T), style = "bootstrap")
+```
+
 # CHANGES IN DT VERSION 0.29
 
 - Support Bootstrap 5 with `datatable(style = "auto")` (thanks, @gadenbuie, #1074).

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -933,8 +933,7 @@ DTDependencies = function(style) {
 # translate DataTables classes to Bootstrap table classes
 DT2BSClass = function(class) {
   if (is.list(class)) {
-    chosen_classes = Filter(function(x) isTRUE(x), class)
-    class = names(chosen_classes)
+    class = names(which(unlist(class)))
   } else {
     class = unlist(strsplit(class, '\\s+'))
   }

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -938,10 +938,8 @@ DT2BSClass = function(class) {
   } else {
     unlist(strsplit(class, '\\s+'))
   }
-
-  if ('display' %in% class) {
+  if ('display' %in% class)
     class = unique(c('stripe', 'hover', 'row-border', 'order-column', class))
-  }
 
   BSclass = c(
     'cell-border' = 'table-bordered', 'compact' = 'table-condensed',

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -940,7 +940,6 @@ DT2BSClass = function(class) {
   }
   if ('display' %in% class)
     class = unique(c('stripe', 'hover', 'row-border', 'order-column', class))
-
   BSclass = c(
     'cell-border' = 'table-bordered', 'compact' = 'table-condensed',
     'hover' = 'table-hover', 'stripe' = 'table-striped'

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -933,10 +933,10 @@ DTDependencies = function(style) {
 
 # translate DataTables classes to Bootstrap table classes
 DT2BSClass = function(class) {
-  if (is.list(class)) {
-    class = names(which(unlist(class)))
+  class = if (is.list(class)) {
+    names(which(unlist(class)))
   } else {
-    class = unlist(strsplit(class, '\\s+'))
+    unlist(strsplit(class, '\\s+'))
   }
 
   if ('display' %in% class) {

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -932,9 +932,17 @@ DTDependencies = function(style) {
 
 # translate DataTables classes to Bootstrap table classes
 DT2BSClass = function(class) {
-  class = unlist(strsplit(class, '\\s+'))
-  if ('display' %in% class)
+  if (is.list(class)) {
+    chosen_classes = Filter(function(x) isTRUE(x), class)
+    class = names(chosen_classes)
+  } else {
+    class = unlist(strsplit(class, '\\s+'))
+  }
+
+  if ('display' %in% class) {
     class = unique(c('stripe', 'hover', 'row-border', 'order-column', class))
+  }
+
   BSclass = c(
     'cell-border' = 'table-bordered', 'compact' = 'table-condensed',
     'hover' = 'table-hover', 'stripe' = 'table-striped'


### PR DESCRIPTION
This PR seeks to bring support for a list of classes in `DT2BSClass()`, with the end goal of fixing the issue #1052.

In more details, when you select `style='bootstrap'`, `DT::datatable()` tries to translate the `class` argument, to a css rule with all the Bootstrap classes that were mentioned in the `class` argument. To make this translation, the `DT2BSClass()` function is called with the class argument. However, the `DT2BSClass()` function only supports a character vector as input.

This PR will allow `DT2BSClass()` to receive a list of booleans as input, as mentioned in the example from issue #1052.
```r
# Now these examples below works
DT::datatable(mtcars, class=list(stripe=F), style = "bootstrap")
DT::datatable(mtcars, class=list(stripe=T, compact=F, hover=T), style = "bootstrap")
```

In essence, we use `base::Filter()` to select the elements of the list that are TRUE, and simply extract the name of these filtered elements.
```r
  if (is.list(class)) {
    chosen_classes = Filter(function(x) isTRUE(x), class)
    class = names(chosen_classes)
  }
```