### PR TITLE
Fix disabling selection on hyperlink click

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Upgraded DataTables version to 1.13.6 (thanks, @stla, #1091).
 
+- Fixed disabling selection on hyperlink click. (@guoci, #1093)
+
 # CHANGES IN DT VERSION 0.30
 
 - Fixed a bug that when using `updateSearch()`, the clear button inside the input box doesn't show up, and the table doesn't update when the input is cleared (thanks, @DavidBlairs, #1082).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Upgraded DataTables version to 1.13.6 (thanks, @stla, #1091).
 
-- Fixed disabling selection on hyperlink click. (@guoci, #1093)
+- Fixed disabling selection on hyperlink clicks (thanks, @guoci, #1093).
 
 # CHANGES IN DT VERSION 0.30
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1372,7 +1372,7 @@ HTMLWidgets.widget({
     changeInput('cell_clicked', {});
 
     // do not trigger table selection when clicking on links unless they have classes
-    table.on('click.dt', 'tbody td a', function(e) {
+    table.on('mousedown.dt', 'tbody td a', function(e) {
       if (this.className === '') e.stopPropagation();
     });
 


### PR DESCRIPTION
Fix disabling selection on hyperlink click, it is currently not working.
Selection is triggered by `mousedown`, so disabling selection on hyperlink click should also use the `mousedown` event.