### PR TITLE
Bugfix: Correctly sort re-ordered columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Upgraded DataTables version to 1.13.6 (thanks, @stla, #1091).
 
+- Searching and sorting work now when columns are re-ordered by the `ColReorder` extension (thanks, @ashbaldry #1096, @gergness #534, @nmoraesmunter #921, @isthisthat #1069).
+
 - Fixed disabling selection on hyperlink clicks (thanks, @guoci, #1093).
 
 - Fixed an error for R >= 4.3.0 (thanks, @AntoineMichelet, #1095).

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -257,10 +257,6 @@ datatable = function(
   if (is.null(options[['autoWidth']])) options$autoWidth = FALSE
   # disable CSS classes for ordered columns
   if (is.null(options[['orderClasses']])) options$orderClasses = FALSE
-  # enable column names for column reordering by default
-  if (is.null(options[['columns']])) {
-    options$columns = lapply(names(data), function(e) list(name = e))
-  }
 
   cn = base::colnames(data)
   if (missing(colnames)) {
@@ -278,6 +274,10 @@ datatable = function(
   # do not order the first column if the name is empty (a column for row names)
   if (length(colnames) && colnames[1] == ' ')
     options = appendColumnDefs(options, list(orderable = FALSE, targets = 0))
+
+  # enable column names for column reordering by default
+  for (j in seq_len(ncol(data)))
+    options = appendColumnDefs(options, list(name = names(data)[j], targets = j - 1))
 
   style = normalizeStyle(style)
   if (grepl('^bootstrap', style)) class = DT2BSClass(class)

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -257,6 +257,10 @@ datatable = function(
   if (is.null(options[['autoWidth']])) options$autoWidth = FALSE
   # disable CSS classes for ordered columns
   if (is.null(options[['orderClasses']])) options$orderClasses = FALSE
+  # enable column names for column reordering by default
+  if (is.null(options[['columns']])) {
+    options$columns = lapply(names(data), function(e) list(name = e))
+  }
 
   cn = base::colnames(data)
   if (missing(colnames)) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -614,10 +614,22 @@ dataTablesFilter = function(data, params) {
     DT_rows_current = list()
   ))
 
+  # map DataTables's column index in the query (`i` here) to the actual column
+  # index in data via its name because the two indices won't match when columns
+  # are reordered via the colReorder extension
+  imap = unlist(lapply(q$columns, function(col) {
+    k = col[['name']]
+    if (!is.character(k) || k == '') return(0L)
+    i = match(k, names(data))
+    if (is.na(i)) stop("The column name '", k, "' is not found in data.")
+    i
+  }))
+  if (all(imap == 0)) imap[] = seq_len(ncol(data))
+
   # which columns are searchable?
   searchable = logical(ncol(data))
-  for (j in seq_len(ncol(data))) {
-    if (q$columns[[j]][['searchable']] == 'true') searchable[j] = TRUE
+  for (j in names(q$columns)) {
+    if (q$columns[[j]][['searchable']] == 'true') searchable[imap[j]] = TRUE
   }
 
   # global searching options (column search shares caseInsensitive)
@@ -634,16 +646,16 @@ dataTablesFilter = function(data, params) {
   # search by columns
   if (length(i)) for (j in names(q$columns)) {
     col = q$columns[[j]]
+    j = imap[j]
     # if the j-th column is not searchable or the search string is "", skip it
-    if (col[['searchable']] != 'true') next
+    if (!searchable[j]) next
     if ((k <- col[['search']][['value']]) == '') next
     k = httpuv::decodeURIComponent(k)
     column_opts = list(
       regex = col[['search']][['regex']] != 'false',
       caseInsensitive = global_opts$caseInsensitive
     )
-    j = as.integer(j)
-    dj = data[i, j + 1]
+    dj = data[i, j]
     i = i[doColumnSearch(dj, k, options = column_opts)]
     if (length(i) == 0) break
   }
@@ -663,11 +675,8 @@ dataTablesFilter = function(data, params) {
   for (ord in q$order) {
     k = ord[['column']]  # which column to sort
     d = ord[['dir']]     # direction asc/desc
-    # If colReorder is enabled, need to find column name rather than index
-    l = q$columns[[k]][['name']]
-    if (l %in% names(data)) k = as.character(match(l, names(data)) - 1)
     if (q$columns[[k]][['orderable']] != 'true') next
-    col = data[, as.integer(k) + 1]
+    col = data[, imap[k]]
     oList[[length(oList) + 1]] = (if (d == 'asc') identity else `-`)(
       if (is.numeric(col)) col else xtfrm(col)
     )

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -663,6 +663,9 @@ dataTablesFilter = function(data, params) {
   for (ord in q$order) {
     k = ord[['column']]  # which column to sort
     d = ord[['dir']]     # direction asc/desc
+    # If colReorder is enabled, need to find column name rather than index
+    l = q$columns[[k]][['name']]
+    if (l %in% names(data)) k = as.character(match(l, names(data)) - 1)
     if (q$columns[[k]][['orderable']] != 'true') next
     col = data[, as.integer(k) + 1]
     oList[[length(oList) + 1]] = (if (d == 'asc') identity else `-`)(

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -432,6 +432,8 @@ HTMLWidgets.widget({
         regex = options.search.regex,
         ci = options.search.caseInsensitive !== false;
       }
+      // need to transpose the column index when colReorder is enabled
+      if (table.colReorder) i = table.colReorder.transpose(i);
       return table.column(i).search(value, regex, !regex, ci);
     };
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -511,7 +511,7 @@ HTMLWidgets.widget({
               if (value.length) $input.trigger('input');
               $input.attr('title', $input.val());
               if (server) {
-                table.column(i).search(value.length ? JSON.stringify(value) : '').draw();
+                searchColumn(i, value.length ? JSON.stringify(value) : '').draw();
                 return;
               }
               // turn off filter if nothing selected
@@ -682,7 +682,7 @@ HTMLWidgets.widget({
             updateSliderText(val[0], val[1]);
             if (e.type === 'slide') return;  // no searching when sliding only
             if (server) {
-              table.column(i).search($td.data('filter') ? ival : '').draw();
+              searchColumn(i, $td.data('filter') ? ival : '').draw();
               return;
             }
             table.draw();

--- a/tests/testit/test-sort.R
+++ b/tests/testit/test-sort.R
@@ -1,0 +1,74 @@
+library(testit)
+
+# Helpers to create client queries that run without errors
+clientQuery = function(data, columns = lapply(names(data), columnQuery)) {
+  columns = rep_len(columns, ncol(data))
+  names(columns) = seq_len(ncol(data)) - 1
+  list(
+    draw = '0',
+    start = '0',
+    length = '10',
+    escape = 'true',
+    search = list(
+      value = '',
+      regex = 'false',
+      caseInsensitive = 'true',
+      smart = 'true'
+    ),
+    columns = columns,
+    order = list()
+  )
+}
+
+columnQuery = function(name = '', orderable = TRUE) {
+  list(
+    name = name,
+    orderable = tolower(orderable),
+    searchable = 'true',
+    search = list(value = '', regex = 'false')
+  )
+}
+
+orderQuery = function(column, dir = 'asc') {
+  list(
+    column = column,
+    dir = dir
+  )
+}
+
+assert('server-side sort handler works', {
+  tbl = data.frame(
+    foo = c('foo', 'bar', 'baz'),
+    bar = c('bar', 'baz', 'foo')
+  )
+
+  query = clientQuery(tbl)
+  out = dataTablesFilter(tbl, query)
+  (identical(out$data, unname(tbl)))
+
+  query = clientQuery(tbl)
+  query$order[[1]] = orderQuery('0', 'asc')
+  tbl_sort = tbl[order(tbl$foo), ]
+  out = dataTablesFilter(tbl, query)
+  (identical(out$data, unname(tbl_sort)))
+
+  query = clientQuery(tbl)
+  query$order[[1]] = orderQuery('1', 'desc')
+  tbl_sort = tbl[order(tbl$bar, decreasing = TRUE), ]
+  out = dataTablesFilter(tbl, query)
+  (identical(out$data, unname(tbl_sort)))
+})
+
+assert('server-side sort handler works with re-ordered columns', {
+  tbl = data.frame(
+    foo = c('foo', 'bar', 'baz'),
+    bar = c('bar', 'baz', 'foo')
+  )
+
+  query = clientQuery(tbl, lapply(c("bar", "foo"), columnQuery))
+  # order is indexed against re-ordered columns
+  query$order[[1]] = orderQuery('0', 'asc')
+  tbl_sort = tbl[order(tbl$bar), ]
+  out = dataTablesFilter(tbl, query)
+  (identical(out$data, unname(tbl_sort)))
+})

--- a/tests/testit/test-sort.R
+++ b/tests/testit/test-sort.R
@@ -48,19 +48,19 @@ assert('server-side sort handler works', {
 
   query = clientQuery(tbl)
   out = dataTablesFilter(tbl, query)
-  (identical(out$data, unname(tbl)))
+  (out$data %==% unname(tbl))
 
   query = clientQuery(tbl)
   query$order[[1]] = orderQuery('0', 'asc')
   tbl_sort = tbl[order(tbl$foo), ]
   out = dataTablesFilter(tbl, query)
-  (identical(out$data, unname(tbl_sort)))
+  (out$data %==% unname(tbl_sort))
 
   query = clientQuery(tbl)
   query$order[[1]] = orderQuery('1', 'desc')
   tbl_sort = tbl[order(tbl$bar, decreasing = TRUE), ]
   out = dataTablesFilter(tbl, query)
-  (identical(out$data, unname(tbl_sort)))
+  (out$data %==% unname(tbl_sort))
 })
 
 assert('server-side sort handler works with re-ordered columns', {
@@ -74,5 +74,7 @@ assert('server-side sort handler works with re-ordered columns', {
   query$order[[1]] = orderQuery('0', 'asc')
   tbl_sort = tbl[order(tbl$bar), ]
   out = dataTablesFilter(tbl, query)
-  (identical(out$data, unname(tbl_sort)))
+  (out$data %==% unname(tbl_sort))
 })
+
+options(op)

--- a/tests/testit/test-sort.R
+++ b/tests/testit/test-sort.R
@@ -1,5 +1,9 @@
 library(testit)
 
+# Factors and strings are searched differently.
+# Older versions of R don't have this set.
+op = options(stringsAsFactors = FALSE)
+
 # Helpers to create client queries that run without errors
 clientQuery = function(data, columns = lapply(names(data), columnQuery)) {
   columns = rep_len(columns, ncol(data))


### PR DESCRIPTION
The re-ordered column order isn't sent server-side, so have added the column names to the DT options. This gets passed into the server-side parameters in `columns$[[col_id]]$name` (adding it to `data` instead caused errors)

This PR should resolve #534 , #921 and #1069