### PR TITLE
Update numeric slider values on updateSearch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.31.2
+Version: 0.31.3
 Authors@R: c(
     person("Yihui", "Xie", email = "xie@yihui.name", role = c("aut", "cre")),
     person("Joe", "Cheng", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN DT VERSION 0.32
 
+- `updateSearch()` now sets the slider values based on the new search string for numeric columns (thanks, @mikmart, #1110).
 
 # CHANGES IN DT VERSION 0.31
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1402,9 +1402,9 @@ HTMLWidgets.widget({
           console.log('The search keyword for column ' + i + ' is undefined')
           return;
         }
-        // Change event is needed to update numeric slider values.
+        // Update column search string and values on linked filter widgets.
+        // 'input' for factor and char filters, 'change' for numeric filters.
         $(td).find('input').first().val(v).trigger('input').trigger('change');
-        searchColumn(i, v);
       });
       table.draw();
     }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -498,9 +498,6 @@ HTMLWidgets.widget({
               var v1 = JSON.stringify(filter[0].selectize.getValue()), v2 = $input.val();
               if (v1 === '[]') v1 = '';
               if (v1 !== v2) filter[0].selectize.setValue(v2 === '' ? [] : JSON.parse(v2));
-            },
-            updatesearch: function() {
-              $input.trigger('input');
             }
           });
           var $input2 = $x.children('select');
@@ -536,13 +533,7 @@ HTMLWidgets.widget({
           if (server) {
             fun = $.fn.dataTable.util.throttle(fun, options.searchDelay);
           }
-          $input.on({
-            input: fun,
-            updatesearch: function() {
-              // Bypass any throttling.
-              searchColumn(i, $input.val()).draw();
-            }
-          });
+          $input.on('input', fun);
         } else if (inArray(type, ['number', 'integer', 'date', 'time'])) {
           var $x0 = $x;
           $x = $x0.children('div').first();
@@ -626,10 +617,6 @@ HTMLWidgets.widget({
               if (v[0] != slider_min()) v[0] *= scale;
               if (v[1] != slider_max()) v[1] *= scale;
               filter.val(v);
-            },
-            updatesearch: function () {
-              $input.trigger('input'); // Resets slider if search is empty.
-              $input.trigger('change');
             }
           });
           var formatDate = function(d, isoFmt) {
@@ -1415,7 +1402,9 @@ HTMLWidgets.widget({
           console.log('The search keyword for column ' + i + ' is undefined')
           return;
         }
-        $(td).find('input').first().val(v).trigger('updatesearch');
+        // Update column search string and values on linked filter widgets.
+        // 'input' for factor and char filters, 'change' for numeric filters.
+        $(td).find('input').first().val(v).trigger('input').trigger('change');
       });
       table.draw();
     }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -530,10 +530,16 @@ HTMLWidgets.widget({
           var fun = function() {
             searchColumn(i, $input.val()).draw();
           };
-          if (server) {
-            fun = $.fn.dataTable.util.throttle(fun, options.searchDelay);
-          }
-          $input.on('input', fun);
+          var throttledFun = $.fn.dataTable.util.throttle(fun, options.searchDelay);
+          $input.on('input', function(e, immediate) {
+            if (immediate) {
+              fun(); // Allows updateSearch to bypass throttling.
+            } else if (server) {
+              throttledFun();
+            } else {
+              fun();
+            }
+          });
         } else if (inArray(type, ['number', 'integer', 'date', 'time'])) {
           var $x0 = $x;
           $x = $x0.children('div').first();
@@ -1404,7 +1410,7 @@ HTMLWidgets.widget({
         }
         // Update column search string and values on linked filter widgets.
         // 'input' for factor and char filters, 'change' for numeric filters.
-        $(td).find('input').first().val(v).trigger('input').trigger('change');
+        $(td).find('input').first().val(v).trigger('input', [true]).trigger('change');
       });
       table.draw();
     }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1402,7 +1402,8 @@ HTMLWidgets.widget({
           console.log('The search keyword for column ' + i + ' is undefined')
           return;
         }
-        $(td).find('input').first().val(v).trigger('input');
+        // Change event is needed to update numeric slider values.
+        $(td).find('input').first().val(v).trigger('input').trigger('change');
         searchColumn(i, v);
       });
       table.draw();

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -530,15 +530,11 @@ HTMLWidgets.widget({
           var fun = function() {
             searchColumn(i, $input.val()).draw();
           };
+          // throttle searching for server-side processing
           var throttledFun = $.fn.dataTable.util.throttle(fun, options.searchDelay);
           $input.on('input', function(e, immediate) {
-            if (immediate) {
-              fun(); // Allows updateSearch to bypass throttling.
-            } else if (server) {
-              throttledFun();
-            } else {
-              fun();
-            }
+            // always bypass throttling when immediate = true (via the updateSearch method)
+            (immediate || !server) ? fun() : throttledFun();
           });
         } else if (inArray(type, ['number', 'integer', 'date', 'time'])) {
           var $x0 = $x;

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -498,6 +498,9 @@ HTMLWidgets.widget({
               var v1 = JSON.stringify(filter[0].selectize.getValue()), v2 = $input.val();
               if (v1 === '[]') v1 = '';
               if (v1 !== v2) filter[0].selectize.setValue(v2 === '' ? [] : JSON.parse(v2));
+            },
+            updatesearch: function() {
+              $input.trigger('input');
             }
           });
           var $input2 = $x.children('select');
@@ -533,7 +536,13 @@ HTMLWidgets.widget({
           if (server) {
             fun = $.fn.dataTable.util.throttle(fun, options.searchDelay);
           }
-          $input.on('input', fun);
+          $input.on({
+            input: fun,
+            updatesearch: function() {
+              // Bypass any throttling.
+              searchColumn(i, $input.val()).draw();
+            }
+          });
         } else if (inArray(type, ['number', 'integer', 'date', 'time'])) {
           var $x0 = $x;
           $x = $x0.children('div').first();
@@ -617,6 +626,10 @@ HTMLWidgets.widget({
               if (v[0] != slider_min()) v[0] *= scale;
               if (v[1] != slider_max()) v[1] *= scale;
               filter.val(v);
+            },
+            updatesearch: function () {
+              $input.trigger('input'); // Resets slider if search is empty.
+              $input.trigger('change');
             }
           });
           var formatDate = function(d, isoFmt) {
@@ -1402,9 +1415,7 @@ HTMLWidgets.widget({
           console.log('The search keyword for column ' + i + ' is undefined')
           return;
         }
-        // Update column search string and values on linked filter widgets.
-        // 'input' for factor and char filters, 'change' for numeric filters.
-        $(td).find('input').first().val(v).trigger('input').trigger('change');
+        $(td).find('input').first().val(v).trigger('updatesearch');
       });
       table.draw();
     }


### PR DESCRIPTION
Fixes #1110.

``` r
library(shiny)
library(DT)

ui <- fluidPage(
  actionButton("set_search", "Set column search"),
  tags$hr(),
  DTOutput("iris")
)

server <- function(input, output, session) {
  output$iris <- renderDT(
    datatable(iris, filter = "top")
  )

  proxy <- dataTableProxy("iris")
  observeEvent(input$set_search, {
    updateSearch(proxy, keywords = list(columns = c("", "5.0 ... 6.0")))
  })
}

shinyApp(ui, server)
```

![image](https://github.com/rstudio/DT/assets/13412395/d2e25734-d0e8-4e13-9dcc-807fe4e189d9)
