### PR TITLE
Ignore invalid criteria in SearchBuilder server-side processing

### DIFF
--- a/R/searchbuilder.R
+++ b/R/searchbuilder.R
@@ -1,12 +1,13 @@
 # server-side processing for the SearchBuilder extension
 # https://datatables.net/extensions/searchbuilder/
 
+# returns NULL if the search doesn't contain any valid conditions
 sbEvaluateSearch = function(search, data) {
   # https://datatables.net/reference/option/searchBuilder.preDefined
   stopifnot(search$logic %in% c('AND', 'OR'))
   Reduce(
     switch(search$logic, AND = `&`, OR = `|`),
-    lapply(search$criteria, sbEvaluateCriteria, data)
+    dropNULL(lapply(search$criteria, sbEvaluateCriteria, data))
   )
 }
 
@@ -15,18 +16,24 @@ sbEvaluateCriteria = function(criteria, data) {
   if ('logic' %in% names(criteria)) {
     # this is a sub-group
     sbEvaluateSearch(criteria, data)
-  } else {
+  } else if (sbHasValidCondition(criteria)) {
     # this is a criteria
     cond = criteria$condition
     type = criteria$type
     x = data[[criteria$origData %||% criteria$data]]
     v = sbParseValue(sbExtractValue(criteria), type)
     sbEvaluateCondition(cond, type, x, v)
+  } else {
+    # skip evaluating invalid conditions
   }
 }
 
+sbHasValidCondition = function(criteria) {
+  'condition' %in% names(criteria) && all(sapply(criteria, nzchar))
+}
+
 sbExtractValue = function(criteria) {
-  if (criteria$condition %in% c('between', '!between')) {
+  if ('value2' %in% names(criteria)) {
     # array values are passed in a funny way to R
     c(criteria$value1, criteria$value2)
   } else {

--- a/R/searchbuilder.R
+++ b/R/searchbuilder.R
@@ -1,7 +1,7 @@
 # server-side processing for the SearchBuilder extension
 # https://datatables.net/extensions/searchbuilder/
 
-# returns NULL if the search doesn't contain any valid conditions
+# returns NULL if none of the search criteria are valid
 sbEvaluateSearch = function(search, data) {
   # https://datatables.net/reference/option/searchBuilder.preDefined
   stopifnot(search$logic %in% c('AND', 'OR'))
@@ -24,10 +24,11 @@ sbEvaluateCriteria = function(criteria, data) {
     v = sbParseValue(sbExtractValue(criteria), type)
     sbEvaluateCondition(cond, type, x, v)
   } else {
-    # skip evaluating invalid conditions
+    # just return NULL for criteria with an invalid condition
   }
 }
 
+# check that condition is present and values are non-empty
 sbHasValidCondition = function(criteria) {
   'condition' %in% names(criteria) && all(sapply(criteria, nzchar))
 }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -651,7 +651,8 @@ dataTablesFilter = function(data, params) {
 
   # apply SearchBuilder query if present
   if (!is.null(s <- q$searchBuilder)) {
-    i = which(sbEvaluateSearch(s, data))
+    r = sbEvaluateSearch(s, data)
+    if (!is.null(r)) i = which(r)
   }
 
   # search by columns

--- a/tests/testit/test-searchbuilder.R
+++ b/tests/testit/test-searchbuilder.R
@@ -41,3 +41,7 @@ assert('SearchBuilder complex queries work', {
   )  
   (setequal(which(res), c(2:4, 7)))
 })
+
+assert('SearchBuilder skips evaluating invalid conditions', {
+  (is.null(sbEvaluateCriteria(list(data = 'Sepal.Length'), iris)))
+})


### PR DESCRIPTION
Follow-up to #1113.

Sometimes the client will send SearchBuilder queries that contain incomplete or invalid search criteria. For example, when the user changes the `data` that an existing criteria applies to, a search will be sent to the server with the `condition` component missing. In client-side processing, such invalid criteria are ignored.

This PR aligns server-side processing with the client-side implementation, by returning `NULL` to signal that a condition is invalid and should be ignored or that the search contains no valid criteria.