### PR TITLE
Always update filter widgets with preset `searchCols`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - `updateSearch()` now sets the slider values based on the new search string for numeric columns (thanks, @mikmart, #1110).
 
+- The `searchCols` option now sets the slider values for numeric columns when `server = TRUE` (thanks, @alexvpickering, @mikmart, #998).
+
 - Added server-side processing support for the [SearchBuilder](https://datatables.net/extensions/searchbuilder/) extension (thanks, @AhmedKhaled945, @shrektan, @mikmart, #963).
 
 # CHANGES IN DT VERSION 0.31

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -521,7 +521,6 @@ HTMLWidgets.widget({
               table.draw();  // redraw table, and filters will be applied
             }
           });
-          if (searchCol) filter[0].selectize.setValue(JSON.parse(searchCol));
           filter[0].selectize.on('blur', function() {
             $x.hide().trigger('hide'); $input.parent().show(); $input.trigger('blur');
           });
@@ -702,7 +701,7 @@ HTMLWidgets.widget({
         // processing
         if (server) {
           // if a search string has been pre-set, search now
-          if (searchCol) searchColumn(i, searchCol).draw();
+          if (searchCol) $input.trigger('input').trigger('change');
           return;
         }
 
@@ -748,15 +747,7 @@ HTMLWidgets.widget({
         $.fn.dataTable.ext.search.push(customFilter);
 
         // search for the preset search strings if it is non-empty
-        if (searchCol) {
-          if (inArray(type, ['factor', 'logical'])) {
-            filter[0].selectize.setValue(JSON.parse(searchCol));
-          } else if (type === 'character') {
-            $input.trigger('input');
-          } else if (inArray(type, ['number', 'integer', 'date', 'time'])) {
-            $input.trigger('change');
-          }
-        }
+        if (searchCol) $input.trigger('input').trigger('change');
 
       });
 


### PR DESCRIPTION
Fixes #998.

Apply preset `searchCols` consistently by triggering `input` and `trigger`, just like with `updateSearch` in #1111.