### PR TITLE
Apply column formats to slider labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - Fixed a bug that caused the date picker widget from the DateTime extension to render incorrectly (thanks, @mikmart, #1116).
 
+- Column formatting now also applies to range labels shown on filter sliders (thanks, @GitChub, @mikmart, #247).
+
 # CHANGES IN DT VERSION 0.31
 
 - Upgraded DataTables version to 1.13.6 (thanks, @stla, #1091).

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -668,11 +668,12 @@ HTMLWidgets.widget({
             r1  = t1; r2 = t2;
           })();
           var updateSliderText = function(v1, v2) {
-            // apply column formatting if defined
+            // format with active column renderer, if defined
             var colDef = data.options.columnDefs.find(function(def) {
               return (def.targets === i || inArray(i, def.targets)) && 'render' in def;
             });
-            if (colDef) {
+            // we only know how to use function renderers
+            if (colDef && typeof colDef.render === 'function') {
               $span1.text(colDef.render(scaleBack(v1, scale), 'display'));
               $span2.text(colDef.render(scaleBack(v2, scale), 'display'));
             } else {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -668,7 +668,17 @@ HTMLWidgets.widget({
             r1  = t1; r2 = t2;
           })();
           var updateSliderText = function(v1, v2) {
-            $span1.text(formatDate(v1, false)); $span2.text(formatDate(v2, false));
+            // apply column formatting if defined
+            var colDef = data.options.columnDefs.find(function(def) {
+              return (def.targets === i || inArray(i, def.targets)) && 'render' in def;
+            });
+            if (colDef) {
+              $span1.text(colDef.render(scaleBack(v1, scale), 'display'));
+              $span2.text(colDef.render(scaleBack(v2, scale), 'display'));
+            } else {
+              $span1.text(formatDate(v1, false));
+              $span2.text(formatDate(v2, false));
+            }
           };
           updateSliderText(r1, r2);
           var updateSlider = function(e) {

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -674,8 +674,12 @@ HTMLWidgets.widget({
             });
             // we only know how to use function renderers
             if (colDef && typeof colDef.render === 'function') {
-              $span1.text(colDef.render(scaleBack(v1, scale), 'display'));
-              $span2.text(colDef.render(scaleBack(v2, scale), 'display'));
+              var restore = function(v) {
+                v = scaleBack(v, scale);
+                return type !== 'date' ? v : new Date(+v);
+              }
+              $span1.text(colDef.render(restore(v1), 'display'));
+              $span2.text(colDef.render(restore(v2), 'display'));
             } else {
               $span1.text(formatDate(v1, false));
               $span2.text(formatDate(v2, false));

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -667,11 +667,11 @@ HTMLWidgets.widget({
             }
             r1  = t1; r2 = t2;
           })();
+          // format with active column renderer, if defined
+          var colDef = data.options.columnDefs.find(function(def) {
+            return (def.targets === i || inArray(i, def.targets)) && 'render' in def;
+          });
           var updateSliderText = function(v1, v2) {
-            // format with active column renderer, if defined
-            var colDef = data.options.columnDefs.find(function(def) {
-              return (def.targets === i || inArray(i, def.targets)) && 'render' in def;
-            });
             // we only know how to use function renderers
             if (colDef && typeof colDef.render === 'function') {
               var restore = function(v) {


### PR DESCRIPTION
Fixes #247.

The `format*` functions append new `columnDefs` entries with customized renderer functions to apply column formatting. The idea in this PR is to fetch those same renderer functions to apply to filter slider labels.

``` r
DT::datatable(
  tibble::tibble(
    goal_completion = round(runif(10), 2),
    bonus = goal_completion * 15:24 * 1000,
    payday = Sys.Date() + 1:10
  ),
  filter = "top"
) |>
  DT::formatPercentage(1) |>
  DT::formatCurrency(2) |>
  DT::formatDate(3)
```
![rstudio_q1oywttPsw](https://github.com/rstudio/DT/assets/13412395/de06454d-d177-43f0-8266-7ccb43f4f7de)
