### PR TITLE
Remove special-casing of dates for slider formatting and fix datetimes

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -127,8 +127,6 @@ formatSignif = function(
 #'   \code{params = list('ko-KR', list(year = 'numeric', month = 'long', day =
 #'   'numeric'))}
 formatDate = function(table, columns, method = 'toDateString', params = NULL, rows = NULL) {
-  if (!inherits(table, 'datatables'))
-    stop("Invalid table argument; a table object created from datatable() was expected")
   formatColumns(table, columns, tplDate, method, params, rows = rows)
 }
 

--- a/R/format.R
+++ b/R/format.R
@@ -129,21 +129,6 @@ formatSignif = function(
 formatDate = function(table, columns, method = 'toDateString', params = NULL, rows = NULL) {
   if (!inherits(table, 'datatables'))
     stop("Invalid table argument; a table object created from datatable() was expected")
-  x = table$x
-  if (x$filter != 'none') {
-    if (inherits(columns, 'formula')) columns = all.vars(columns)
-    colnames = base::attr(x, 'colnames', exact = TRUE)
-    rownames = base::attr(x, 'rownames', exact = TRUE)
-    if (is.null(params)) params = list()
-    cols = sprintf("%d", name2int(columns, colnames, rownames))
-    x$filterDateFmt = as.list(x$filterDateFmt)
-    for (col in cols) x$filterDateFmt[[col]] = list(
-      method = method, params = toJSON(params)
-    )
-    table$x = x
-  }
-  # the code above is used to ensure the date(time) filter displays the same format or
-  # timezone as the column value
   formatColumns(table, columns, tplDate, method, params, rows = rows)
 }
 

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -684,7 +684,7 @@ HTMLWidgets.widget({
             if (colDef && typeof colDef.render === 'function') {
               var restore = function(v) {
                 v = scaleBack(v, scale);
-                return type !== 'date' ? v : new Date(+v);
+                return inArray(type, ['date', 'time']) ? new Date(+v) : v;
               }
               $span1.text(colDef.render(restore(v1), 'display'));
               $span2.text(colDef.render(restore(v2), 'display'));

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -630,13 +630,11 @@ HTMLWidgets.widget({
               filter.val(v);
             }
           });
-          var formatDate = function(d, isoFmt) {
+          var formatDate = function(d) {
             d = scaleBack(d, scale);
             if (type === 'number') return d;
             if (type === 'integer') return parseInt(d);
             var x = new Date(+d);
-            var fmt = ('filterDateFmt' in data) ? data.filterDateFmt[i] : undefined;
-            if (fmt !== undefined && isoFmt === false) return x[fmt.method].apply(x, fmt.params);
             if (type === 'date') {
               var pad0 = function(x) {
                 return ('0' + x).substr(-2, 2);
@@ -691,8 +689,8 @@ HTMLWidgets.widget({
               $span1.text(colDef.render(restore(v1), 'display'));
               $span2.text(colDef.render(restore(v2), 'display'));
             } else {
-              $span1.text(formatDate(v1, false));
-              $span2.text(formatDate(v2, false));
+              $span1.text(formatDate(v1));
+              $span2.text(formatDate(v2));
             }
           };
           updateSliderText(r1, r2);


### PR DESCRIPTION
Follow-up to #1119.

This PR removes the now-unnecessary special-casing from `formatDate()` as the mechanism from #1119 handles it directly.

This also fixes a regression introduced in #1119 for datetime columns, which was caused by me overlooking to handle datetime values when applying a renderer to format the slider range labels.

There's some duplicated logic in the JS side `formatDate()` helper and `restore()`. I thought about refactoring that, but it would be a slightly more involved operation without a big direct benefit, so I decided not to mess with it at this point.

I tested manually with this app:

``` r
DT::datatable(
  data.frame(
    date = Sys.Date() + 1:10,
    time = Sys.time() + 1:10 * 60 * 60 * 24
  ),
  filter = "top"
) |> DT::formatDate(1:2, "toLocaleString")
```