### PR TITLE
fix selection sync on client mode update (fixes #1125)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fixed a bug in `renderDT()`'s evaluation of `...` arguments when `quoted = TRUE` (#1130). 
 
+- Maintain selected columns/rows/cells upon re-render (thanks, @epruesse, #1125).
+
 # CHANGES IN DT VERSION 0.32
 
 - Fixed a bug that caused the column used for grouping with the RowGroup extension to change when relocated by the ColReorder extension (thanks, @isthisthat, @mikmart, #1109).

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -1032,6 +1032,9 @@ HTMLWidgets.widget({
         updateColsSelected();
         updateCellsSelected();
       })
+      updateRowsSelected();
+      updateColsSelected();
+      updateCellsSelected();
     }
 
     var selMode = data.selection.mode, selTarget = data.selection.target;


### PR DESCRIPTION
This is "minimally invasive". After the reload of the table on the client and potentially restoring selections via JS callback function, the `cleanSelectedValues()` function sends potentially incorrect `<tbl>_xxx_selected` information to R. The patch uses the functions already implemented to send row/col/cell selections made via Select extension to R. It simply triggers one update right then and there. Since the messages get merged, this effectively overwrites the false message created by cleanSelectedValues() exactly when the bug #1125 is triggered. It may not be a complete fix for other scenarios, but it is brief and has minimal chance of breaking things for other use cases.