### PR TITLE
Add renderDT(outputArgs=), remove doc dependency on deprecated Shiny funcs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN DT VERSION 0.33
 
+- Added `outputArgs` parameter to `renderDataTable`, to allow width and height to be set when using interactive R Markdown documents.
 
 # CHANGES IN DT VERSION 0.32
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -4,7 +4,7 @@
 #' functions in the \pkg{shiny} package. The former is used to create a
 #' container for table, and the latter is used in the server logic to render the
 #' table.
-#' @inheritParams shiny::dataTableOutput
+#' @param outputId output variable to read the table from
 #' @param width the width of the table container
 #' @param height the height of the table container
 #' @param fill passed to \code{htmlwidgets::\link{shinyWidgetOutput}()}, see
@@ -42,7 +42,6 @@ DTOutput = dataTableOutput
 
 #' @export
 #' @rdname dataTableOutput
-#' @inheritParams shiny::renderDataTable
 #' @param expr an expression to create a table widget (normally via
 #'   \code{\link{datatable}()}), or a data object to be passed to
 #'   \code{datatable()} to create a table widget
@@ -53,17 +52,31 @@ DTOutput = dataTableOutput
 #'   browsers to slow down or crash. Note that if you want to use
 #'   \code{renderDataTable} with \code{shiny::bindCache()}, this must be
 #'   \code{FALSE}.
+#' @param env The parent environment for the reactive expression. By default,
+#'   this is the calling environment, the same as when defining an ordinary
+#'   non-reactive expression. If \code{expr} is a quosure and \code{quoted} is
+#'   \code{TRUE}, then \code{env} is ignored.
+#' @param quoted If it is \code{TRUE}, then the
+#'   \code{\link[substitute]{quote}()}ed value of \code{expr} will be used when
+#'   \code{expr} is evaluated. If \code{expr} is a quosure and you would like to
+#'   use its expression as a value for \code{expr}, then you must set
+#'   \code{quoted} to \code{TRUE}.
 #' @param funcFilter (for expert use only) passed to the \code{filter} argument
 #'   of \code{\link{dataTableAjax}()}
 #' @param future whether the server-side filter function should be executed
 #'   as a future or as a standard synchronous function. If true, the future
 #'   will be evaluated according to the session's \link[future]{plan}.
+#' @param outputArgs A list of arguments to be passed through to the implicit
+#'   call to \code{\link{dataTableOutput}()} when
+#'   \code{\link{renderDataTable}()} is used in an interactive R Markdown
+#'   document.
 #' @param ... ignored when \code{expr} returns a table widget, and passed as
 #'   additional arguments to \code{\link{datatable}()} when \code{expr} returns
 #'   a data object
 renderDataTable = function(
     expr, server = TRUE, env = parent.frame(), quoted = FALSE,
-    funcFilter = dataTablesFilter, future = FALSE, ...
+    funcFilter = dataTablesFilter, future = FALSE,
+    outputArgs = list(), ...
   ) {
   if (!quoted) expr = substitute(expr)
 
@@ -172,6 +185,7 @@ renderDataTable = function(
         removeTimestampFromSnapshot(name)
         promises::with_promise_domain(domain, renderFunc())
       },
+      outputArgs = outputArgs,
       cacheHint = cacheHint
     )
   } else {
@@ -181,7 +195,8 @@ renderDataTable = function(
         domain = tempVarsPromiseDomain(outputInfoEnv, outputName = name, session = shinysession)
         removeTimestampFromSnapshot(name)
         promises::with_promise_domain(domain, renderFunc())
-      }
+      },
+      outputArgs = outputArgs
     )
   }
 

--- a/man/dataTableOutput.Rd
+++ b/man/dataTableOutput.Rd
@@ -18,6 +18,7 @@ renderDataTable(
   quoted = FALSE,
   funcFilter = dataTablesFilter,
   future = FALSE,
+  outputArgs = list(),
   ...
 )
 
@@ -28,6 +29,7 @@ renderDT(
   quoted = FALSE,
   funcFilter = dataTablesFilter,
   future = FALSE,
+  outputArgs = list(),
   ...
 )
 }
@@ -55,12 +57,13 @@ browsers to slow down or crash. Note that if you want to use
 
 \item{env}{The parent environment for the reactive expression. By default,
 this is the calling environment, the same as when defining an ordinary
-non-reactive expression. If \code{expr} is a quosure and \code{quoted} is \code{TRUE},
-then \code{env} is ignored.}
+non-reactive expression. If \code{expr} is a quosure and \code{quoted} is
+\code{TRUE}, then \code{env} is ignored.}
 
-\item{quoted}{If it is \code{TRUE}, then the \code{\link[=quote]{quote()}}ed value of \code{expr}
-will be used when \code{expr} is evaluated. If \code{expr} is a quosure and you
-would like to use its expression as a value for \code{expr}, then you must set
+\item{quoted}{If it is \code{TRUE}, then the
+\code{\link[substitute]{quote}()}ed value of \code{expr} will be used when
+\code{expr} is evaluated. If \code{expr} is a quosure and you would like to
+use its expression as a value for \code{expr}, then you must set
 \code{quoted} to \code{TRUE}.}
 
 \item{funcFilter}{(for expert use only) passed to the \code{filter} argument
@@ -69,6 +72,11 @@ of \code{\link{dataTableAjax}()}}
 \item{future}{whether the server-side filter function should be executed
 as a future or as a standard synchronous function. If true, the future
 will be evaluated according to the session's \link[future]{plan}.}
+
+\item{outputArgs}{A list of arguments to be passed through to the implicit
+call to \code{\link{dataTableOutput}()} when
+\code{\link{renderDataTable}()} is used in an interactive R Markdown
+document.}
 
 \item{...}{ignored when \code{expr} returns a table widget, and passed as
 additional arguments to \code{\link{datatable}()} when \code{expr} returns


### PR DESCRIPTION
We're transitioning toward removing `shiny::dataTableOutput` and `shiny::renderDataTable` and having them shim their DT equivalents. (see https://github.com/rstudio/shiny/issues/3986)

Neither the addition of `outputArgs` nor the removal of the `@inheritParams` are urgently needed, just thought I'd do this while I was thinking of it.