### PR TITLE
Always evaluate `renderDT()`'s `...` in the `parent.frame()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # CHANGES IN DT VERSION 0.33
 
 - Added `outputArgs` parameter to `renderDataTable`, to allow width and height to be set when using interactive R Markdown documents.
-- Fixed a bug in `renderDT()`'s evaluation of `...` arguments when `quoted = TRUE`. (#1130) 
+
+- Fixed a bug in `renderDT()`'s evaluation of `...` arguments when `quoted = TRUE` (#1130). 
 
 # CHANGES IN DT VERSION 0.32
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # CHANGES IN DT VERSION 0.33
 
 - Added `outputArgs` parameter to `renderDataTable`, to allow width and height to be set when using interactive R Markdown documents.
+- Fixed a bug in `renderDT()`'s evaluation of `...` arguments when `quoted = TRUE`. (#1130) 
 
 # CHANGES IN DT VERSION 0.32
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -99,7 +99,7 @@ renderDataTable = function(
   outputInfoEnv[["session"]] = NULL
 
   exprFunc = shiny::exprToFunction(expr, env, quoted = TRUE)
-  argFunc = shiny::exprToFunction(list(..., server = server), env, quoted = FALSE)
+  argFunc = shiny::exprToFunction(list(..., server = server), parent.frame(), quoted = FALSE)
   widgetFunc = function() {
     opts = options(DT.datatable.shiny = TRUE); on.exit(options(opts), add = TRUE)
     instance = exprFunc()


### PR DESCRIPTION
Closes #1129