### PR TITLE
Moved function definition

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -99,15 +99,7 @@ renderDataTable = function(
 
   exprFunc = shiny::exprToFunction(expr, env, quoted = TRUE)
   argFunc = shiny::exprToFunction(list(..., server = server), parent.frame(), quoted = FALSE)
-  widgetFunc = function() {
-    opts = options(DT.datatable.shiny = TRUE); on.exit(options(opts), add = TRUE)
-    instance = exprFunc()
-    if (promises::is.promising(instance)) {
-      promises::then(instance, processWidget)
-    } else {
-      processWidget(instance)
-    }
-  }
+
   processWidget = function(instance) {
     args = argFunc()
     server = args$server; args$server = NULL # the last element is `server`
@@ -165,6 +157,16 @@ renderDataTable = function(
     }
 
     instance
+  }
+
+  widgetFunc = function() {
+    opts = options(DT.datatable.shiny = TRUE); on.exit(options(opts), add = TRUE)
+    instance = exprFunc()
+    if (promises::is.promising(instance)) {
+      promises::then(instance, processWidget)
+    } else {
+      processWidget(instance)
+    }
   }
 
   renderFunc = htmlwidgets::shinyRenderWidget(


### PR DESCRIPTION
Hello,

the only purpose of this PR is to change the order of function definition. Currently, `processWidget()` is used in function `widgetFunc()`, but only after it's definition. This makes the package https://github.com/rstudio/shinytest2 fail because it does not allow global variables.

I am aware that this issue is more related to `{shinytest2}` rather than to `{DT}`, but the issue there is stale (https://github.com/rstudio/shinytest2/issues/330). As this change does not affect any functionality, I thought it could be fixed right here.

If I should update also the package version/NEWS or something similar, please, feel free to let me know.

If you do not like this change, I will understand.
Thanks for this package and your hard work :)