### PR TITLE
Add lazyRender parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DT
 Type: Package
 Title: A Wrapper of the JavaScript Library 'DataTables'
-Version: 0.33.1
+Version: 0.33.2
 Authors@R: c(
     person("Yihui", "Xie", role = "aut"),
     person("Joe", "Cheng", email = "joe@posit.co", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # CHANGES IN DT VERSION 0.34
 
-- Added `lazyRender` parameter to `datatable`, which gives the option for the table to be rendered immediately rather than waiting for it to become visible (#1156).
+- Added `lazyRender` parameter to `DT::datatable()`, which gives the option for the table to be rendered immediately rather than waiting for it to become visible (thanks, @Mosk915, #1156).
 
 # CHANGES IN DT VERSION 0.33
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN DT VERSION 0.34
 
+- Added `lazyRender` parameter to `datatable`, which gives the option for the table to be rendered immediately rather than waiting for it to become visible (#1156).
 
 # CHANGES IN DT VERSION 0.33
 

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -209,7 +209,7 @@ datatable = function(
   escape = TRUE, style = 'auto', width = NULL, height = NULL, elementId = NULL,
   fillContainer = getOption('DT.fillContainer', NULL),
   autoHideNavigation = getOption('DT.autoHideNavigation', NULL),
-  lazyRender = TRUE,
+  lazyRender = NULL,
   selection = c('multiple', 'single', 'none'), extensions = list(), plugins = NULL,
   editable = FALSE
 ) {

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -64,6 +64,8 @@
 #'   (only display the table body) when the number of total records is less
 #'   than the page size. Note, it only works on the client-side processing mode
 #'   and the `pageLength` option should be provided explicitly.
+#' @param lazyRender \code{TRUE} to delay rendering until the table becomes visible
+#'   (the default) or \code{FALSE} to render the table immediately on page load.
 #' @param selection the row/column selection mode (single or multiple selection
 #'   or disable selection) when a table widget is rendered in a Shiny app;
 #'   alternatively, you can use a list of the form \code{list(mode = 'multiple',
@@ -207,6 +209,7 @@ datatable = function(
   escape = TRUE, style = 'auto', width = NULL, height = NULL, elementId = NULL,
   fillContainer = getOption('DT.fillContainer', NULL),
   autoHideNavigation = getOption('DT.autoHideNavigation', NULL),
+  lazyRender = TRUE,
   selection = c('multiple', 'single', 'none'), extensions = list(), plugins = NULL,
   editable = FALSE
 ) {
@@ -374,6 +377,9 @@ datatable = function(
               immediate. = TRUE)
     params$autoHideNavigation = autoHideNavigation
   }
+
+  # record lazyRender
+  params$lazyRender = lazyRender
 
   params = structure(modifyList(params, list(
     data = data, container = as.character(container), options = options,

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -379,7 +379,7 @@ datatable = function(
   }
 
   # record lazyRender
-  if(isFALSE(lazyRender)) params$lazyRender = lazyRender
+params$lazyRender = lazyRender
 
   params = structure(modifyList(params, list(
     data = data, container = as.character(container), options = options,

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -379,7 +379,7 @@ datatable = function(
   }
 
   # record lazyRender
-params$lazyRender = lazyRender
+  params$lazyRender = lazyRender
 
   params = structure(modifyList(params, list(
     data = data, container = as.character(container), options = options,

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -379,7 +379,7 @@ datatable = function(
   }
 
   # record lazyRender
-  params$lazyRender = lazyRender
+  if(isFALSE(lazyRender)) params$lazyRender = lazyRender
 
   params = structure(modifyList(params, list(
     data = data, container = as.character(container), options = options,

--- a/R/datatables.R
+++ b/R/datatables.R
@@ -64,8 +64,8 @@
 #'   (only display the table body) when the number of total records is less
 #'   than the page size. Note, it only works on the client-side processing mode
 #'   and the `pageLength` option should be provided explicitly.
-#' @param lazyRender \code{TRUE} to delay rendering until the table becomes visible
-#'   (the default) or \code{FALSE} to render the table immediately on page load.
+#' @param lazyRender \code{FALSE} to render the table immediately on page load,
+#'   otherwise delay rendering until the table becomes visible.
 #' @param selection the row/column selection mode (single or multiple selection
 #'   or disable selection) when a table widget is rendered in a Shiny app;
 #'   alternatively, you can use a list of the form \code{list(mode = 'multiple',

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -180,7 +180,9 @@ HTMLWidgets.widget({
     };
   },
   renderValue: function(el, data, instance) {
-    if (el.offsetWidth === 0 || el.offsetHeight === 0) {
+    if(!data.hasOwnProperty("lazyRender"))
+      data.lazyRender = true;
+    if ((el.offsetWidth === 0 || el.offsetHeight === 0) && data.lazyRender) {
       instance.data = data;
       return;
     }

--- a/inst/htmlwidgets/datatables.js
+++ b/inst/htmlwidgets/datatables.js
@@ -180,9 +180,7 @@ HTMLWidgets.widget({
     };
   },
   renderValue: function(el, data, instance) {
-    if(!data.hasOwnProperty("lazyRender"))
-      data.lazyRender = true;
-    if ((el.offsetWidth === 0 || el.offsetHeight === 0) && data.lazyRender) {
+    if ((el.offsetWidth === 0 || el.offsetHeight === 0) && data.lazyRender !== false) {
       instance.data = data;
       return;
     }

--- a/man/datatable.Rd
+++ b/man/datatable.Rd
@@ -21,6 +21,7 @@ datatable(
   elementId = NULL,
   fillContainer = getOption("DT.fillContainer", NULL),
   autoHideNavigation = getOption("DT.autoHideNavigation", NULL),
+  lazyRender = NULL,
   selection = c("multiple", "single", "none"),
   extensions = list(),
   plugins = NULL,
@@ -104,6 +105,9 @@ then vertical and/or horizontal scrolling of the table cells will occur.}
 (only display the table body) when the number of total records is less
 than the page size. Note, it only works on the client-side processing mode
 and the `pageLength` option should be provided explicitly.}
+
+\item{lazyRender}{\code{FALSE} to render the table immediately on page load,
+otherwise delay rendering until the table becomes visible.}
 
 \item{selection}{the row/column selection mode (single or multiple selection
 or disable selection) when a table widget is rendered in a Shiny app;


### PR DESCRIPTION
This resolves #1156. It adds the option to have the table render immediately rather than waiting for it to become visible.