### PR TITLE
Fix rendering vctrs::list_of columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,8 @@ Suggests:
     rmarkdown,
     shiny (>= 1.6),
     testit,
-    tibble
+    tibble,
+    vctrs
 VignetteBuilder:
     knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # DT (development version)
 
+- Fix error rendering `vctrs::list_of` columns (#1180, @zeehio)
+
 # CHANGES IN DT VERSION 0.34
 
 - DT is now released under the MIT license (previously GPL-3) (#1175).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # DT (development version)
 
-- Fix error rendering `vctrs::list_of` columns (#1180, @zeehio)
+- `datatable()` now renders data frames with `vctrs::list_of()` list-columns (#1180, @zeehio).
 
 # CHANGES IN DT VERSION 0.34
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,6 +44,9 @@ captionString = function(caption) {
 boxAtomicScalarElements = function(x) {
   is_atomic = vapply(x, is.atomic, logical(1))
   if (all(is_atomic)) {
+    if (inherits(x, "vctrs_list_of")) {
+      x <- as.list(x)
+    }
     is_scalar = lengths(x) == 1L
     x[is_scalar] = lapply(x[is_scalar], list)
   }

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -5,6 +5,18 @@ assert('dropNULL() works', {
   (dropNULL(list(a = 1, b = NULL)) %==% list(a = 1))
 })
 
+assert('boxAtomicScalarElements() works with vctrs::list_of lists', {
+  if (requireNamespace("vctrs", quietly = TRUE)) {
+    val1 <- list("a", c("a", "b"))
+    out1 <- boxAtomicScalarElements(val1)
+    val2 <- vctrs::as_list_of(val1)
+    out2 <- boxAtomicScalarElements(val2)
+    (out1 %==% out2)
+  } else {
+    message("test omitted: vctrs is not installed")
+  }
+})
+
 assert('upperToDash() works', {
   (upperToDash('fontWeight') %==% 'font-weight')
   (upperToDash('backgroundColor') %==% 'background-color')

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -14,6 +14,7 @@ assert('boxAtomicScalarElements() works with vctrs::list_of lists', {
     (out1 %==% out2)
   } else {
     message("test omitted: vctrs is not installed")
+    TRUE
   }
 })
 


### PR DESCRIPTION
DT needs to convert data frames/tibbles to json.

The R to json conversion has an ambiguity on scalar vector conversions: R can't tell the difference between an "atomic vector of length 1" and "a scalar", while in json a scalar is `"just the value"` and a vector of length 1 is represented in a list `["just the value"]`.

When our data frame has a list column, we need to resolve this ambiguity. For list-columns, in DT we need each item of the column to be itself a json list. This means that if the item already is a vector of length > 1, we have no trouble, but if the item is a scalar, we need to coerce it to a list to guarantee that the conversion behaves as expected. See the example:

Example:

Imagine in a two-row dataframe we have a list column with the following content: `list(c("a", "b"), "c")`. Each element of this list column needs to become a list when converted to json. Naturally, `c("a", "b")` becomes `["a", "b"]`, but what about `"c"`? It would become `"c"` and we need it to become `["c"]` instead.

In R, both items `c("a", "b")` and `"c"` are character vectors. We need to coerce the second to a list so x becomes `list(c("a", "b"), list("c"))` and the conversion to json works as we require.

The problem:

This coercion fails if the list column is not of type list, but a `vctrs::list_of` with a `ptype=character(0)` vector. In that scenario, when we try to turn "c" (a character vector) into list("c") (a list), `vctrs` steps in and tries to coerce the list back to a character, because `vctrs::list_of` enforces the character type to all elements of the list. This raises a coercion error as seen on #1180.

The easiest solution in this case is to drop the `list_of` type if we need to, and leave the column as a regular list, so items may have mixed types in R -but will have homogeneous types in json!- and the assignment works without coercions from vctrs.

Reprex in the associated issue #1180 .

I added a unit test to prevent regressions and updated the NEWS file.

Closes #1180 
